### PR TITLE
Switch to binary protocol and fix TCP drops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,12 +113,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,8 +370,6 @@ dependencies = [
  "parking_lot",
  "pyo3",
  "pyo3-build-config",
- "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -409,48 +401,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "serde"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.219"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.140"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
-]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,8 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3        = { version = "0.20", features = ["extension-module", "auto-initialize"] }
 numpy       = "0.20"
-tokio       = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tokio       = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 anyhow      = "1"
-serde       = { version = "1", features = ["derive"] }
-serde_json  = "1"
 parking_lot = "0.12"
 once_cell   = "1"
 async-channel = "1"   # used in lib.rs for the broadcast queue


### PR DESCRIPTION
## Summary
- use binary updates instead of JSON
- handle TCP peers using `read_exact`/`write_all`
- remove serde deps and enable tokio's `io-util` feature

## Testing
- `maturin develop --release` *(fails: couldn't find virtualenv)*
- `cargo build --release` *(fails to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683f969d10888332a09bea97afde8632