### PR TITLE
Send array shape with updates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! One `import raftmem` call boots a background Tokio runtime **inside the
 //! Python process**.  You get:
-//!   • A 10‑element `f64` ring mapped into NumPy zero‑copy.
+//!   • A configurable‑length `f64` ring mapped into NumPy zero‑copy.
 //!   • Transparent replication to peer nodes over TCP using simple
 //!     leader‑less broadcast (good‑enough demo).  Change one element → every
 //!     node converges.
@@ -13,9 +13,10 @@
 //! python - <<'PY'
 //! import raftmem, numpy as np, random, time
 //! node = raftmem.start(name="a", listen="0.0.0.0:7000", peers=["nodeB:7001"])
-//! arr  = node.ndarray     # shared   [f64;10]
+//! arr  = node.ndarray     # shared   [f64; n]
 //! while True:
-//!     idx = random.randrange(10); val = random.random()*10
+//!     n = len(arr)
+//!     idx = random.randrange(n); val = random.random()*10
 //!     arr[idx] = val       # ← real NumPy write, replicated
 //!     node.flush(idx)      # tell raftmem to broadcast dirty slot
 //!     print("A", arr)
@@ -73,21 +74,32 @@ static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("tokio"));
 // ---------- in‑memory state -------------------------------------------------
 struct MmapBuf {
     mm: MmapMut,
+    shape: Vec<usize>,
+    len: usize,
 }
 
 impl MmapBuf {
-    fn new() -> Result<Self> {
-        let layout = 10 * std::mem::size_of::<f64>();
+    fn new(shape: Vec<usize>) -> Result<Self> {
+        let len: usize = shape.iter().product();
+        let layout = len * std::mem::size_of::<f64>();
         let mm = MmapOptions::new().len(layout).map_anon()?;
-        Ok(Self { mm })
+        Ok(Self { mm, shape, len })
     }
 
     fn ptr(&self) -> *mut c_void {
         self.mm.as_ptr() as *mut _
     }
 
-    fn len(&self) -> usize {
+    fn byte_len(&self) -> usize {
         self.mm.len()
+    }
+
+    fn elems(&self) -> usize {
+        self.len
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
     }
 }
 
@@ -96,7 +108,7 @@ struct Shared(Arc<MmapBuf>);
 
 impl Shared {
     fn apply(&self, idx: usize, val: f64) {
-        if idx < 10 {
+        if idx < self.0.elems() {
             unsafe {
                 let base = self.0.mm.as_ptr() as *mut f64;
                 *base.add(idx) = val;
@@ -110,45 +122,81 @@ impl Shared {
             *base.add(idx)
         }
     }
+
+    fn elems(&self) -> usize {
+        self.0.elems()
+    }
+
+    fn shape(&self) -> &[usize] {
+        self.0.shape()
+    }
 }
 
 // ---------- wire protocol ---------------------------------------------------
-#[derive(Debug, Clone, Copy)]
-struct Update { idx: u32, val: f64 }
+#[derive(Debug, Clone)]
+struct Update {
+    shape: Vec<u32>,
+    arr: Vec<f64>,
+}
 
 impl Update {
-    const SIZE: usize = 4 + 8; // u32 + f64
-
-    fn to_bytes(&self) -> [u8; Self::SIZE] {
-        let mut buf = [0u8; Self::SIZE];
-        buf[..4].copy_from_slice(&self.idx.to_le_bytes());
-        buf[4..].copy_from_slice(&self.val.to_le_bytes());
+    fn to_bytes(&self) -> Vec<u8> {
+        let shape_len = self.shape.len() as u32;
+        let mut buf = Vec::with_capacity(4 + self.shape.len() * 4 + self.arr.len() * 8);
+        buf.extend_from_slice(&shape_len.to_le_bytes());
+        for d in &self.shape {
+            buf.extend_from_slice(&d.to_le_bytes());
+        }
+        for v in &self.arr {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
         buf
-    }
-
-    fn from_bytes(buf: &[u8; Self::SIZE]) -> Self {
-        let mut idx_bytes = [0u8; 4];
-        idx_bytes.copy_from_slice(&buf[..4]);
-        let idx = u32::from_le_bytes(idx_bytes);
-
-        let mut val_bytes = [0u8; 8];
-        val_bytes.copy_from_slice(&buf[4..]);
-        let val = f64::from_le_bytes(val_bytes);
-
-        Self { idx, val }
     }
 }
 
 async fn handle_peer(mut sock: TcpStream, state: Shared) -> Result<()> {
     let addr = sock.peer_addr().ok();
     println!("peer {:?} connected", addr);
-    let mut buf = [0u8; Update::SIZE];
     loop {
-        match sock.read_exact(&mut buf).await {
+        let mut shape_len_buf = [0u8; 4];
+        match sock.read_exact(&mut shape_len_buf).await {
+            Ok(_) => {}
+            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
+            Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
+            Err(e) => return Err(e.into()),
+        }
+        let shape_len = u32::from_le_bytes(shape_len_buf) as usize;
+        let mut shape_bytes = vec![0u8; shape_len * 4];
+        match sock.read_exact(&mut shape_bytes).await {
+            Ok(_) => {}
+            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
+            Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
+            Err(e) => return Err(e.into()),
+        }
+        let mut shape = Vec::with_capacity(shape_len);
+        for i in 0..shape_len {
+            let mut d = [0u8; 4];
+            d.copy_from_slice(&shape_bytes[i * 4..(i + 1) * 4]);
+            shape.push(u32::from_le_bytes(d) as usize);
+        }
+        let len: usize = shape.iter().product();
+        let mut data = vec![0u8; len * 8];
+        match sock.read_exact(&mut data).await {
             Ok(_) => {
-                let upd = Update::from_bytes(&buf);
-                println!("recv from {:?}: {} -> {}", addr, upd.idx, upd.val);
-                state.apply(upd.idx as usize, upd.val);
+                let mut arr = Vec::with_capacity(len);
+                for i in 0..len {
+                    let mut val_bytes = [0u8; 8];
+                    val_bytes.copy_from_slice(&data[i * 8..(i + 1) * 8]);
+                    arr.push(f64::from_le_bytes(val_bytes));
+                }
+                println!("recv from {:?}: {:?}", addr, arr);
+                if shape != state.shape() {
+                    println!("shape mismatch: recv {:?} local {:?}", shape, state.shape());
+                    continue;
+                }
+                for (i, v) in arr.iter().enumerate() {
+                    state.apply(i, *v);
+                }
             }
             Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
             Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
@@ -172,7 +220,7 @@ async fn broadcaster(peers: Vec<SocketAddr>, rx: async_channel::Receiver<Update>
         }
     }
     while let Some(u) = rx.recv().await.ok() {
-        println!("broadcasting {} -> {}", u.idx, u.val);
+        println!("broadcasting full array shape {:?}", u.shape);
         let data = u.to_bytes();
 
         for p in &peers {
@@ -222,13 +270,15 @@ struct Node {
     name: String,
     state: Shared,
     tx: async_channel::Sender<Update>,
+    shape: Vec<usize>,
+    len: usize,
 }
 
 #[pymethods]
 impl Node {
     #[getter]
     fn ndarray<'py>(&'py self, py: Python<'py>) -> &'py PyArray1<f64> {
-        let dims: [npy_intp; 1] = [10];
+        let dims: [npy_intp; 1] = [self.len as npy_intp];
         let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
@@ -247,14 +297,18 @@ impl Node {
             PyArray1::from_owned_ptr(py, arr_ptr)
         }
     }
-    fn flush(&self, idx: usize) {
-        let val = self.state.get(idx);
-        println!("{} flushing idx {} with {}", self.name, idx, val);
-        let _ = self.tx.try_send(Update { idx: idx as u32, val });
+    fn flush(&self, _idx: usize) {
+        let mut arr = Vec::with_capacity(self.len);
+        for i in 0..self.len {
+            arr.push(self.state.get(i));
+        }
+        println!("{} flushing full array", self.name);
+        let shape: Vec<u32> = self.shape.iter().map(|&d| d as u32).collect();
+        let _ = self.tx.try_send(Update { shape, arr });
     }
 
     fn write<'py>(slf: PyRef<'py, Self>) -> PyResult<WriteGuard> {
-        let len = slf.state.0.len();
+        let len = slf.state.0.byte_len();
         unsafe {
             let ret = mprotect(slf.state.0.mm.as_ptr() as *mut _, len, PROT_READ | PROT_WRITE);
             if ret != 0 {
@@ -265,7 +319,7 @@ impl Node {
     }
 
     fn read<'py>(slf: PyRef<'py, Self>) -> PyResult<ReadGuard> {
-        let len = slf.state.0.len();
+        let len = slf.state.0.byte_len();
         unsafe {
             let ret = mprotect(slf.state.0.mm.as_ptr() as *mut _, len, PROT_READ);
             if ret != 0 {
@@ -277,9 +331,7 @@ impl Node {
 }
 
 fn flush_now(node: &Node) {
-    for idx in 0..10 {
-        node.flush(idx);
-    }
+    node.flush(0);
 }
 
 #[pyclass]
@@ -291,7 +343,7 @@ struct WriteGuard {
 impl WriteGuard {
     fn __enter__<'py>(slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArray1<f64> {
         let cell = slf.node.as_ref(py).borrow();
-        let dims: [npy_intp; 1] = [10];
+        let dims: [npy_intp; 1] = [cell.len as npy_intp];
         let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
@@ -315,7 +367,7 @@ impl WriteGuard {
         Python::with_gil(|py| {
             let cell = self.node.as_ref(py).borrow();
             flush_now(&*cell);
-            let len = cell.state.0.len();
+            let len = cell.state.0.byte_len();
             let ret = unsafe { mprotect(cell.state.0.mm.as_ptr() as *mut _, len, PROT_READ) };
             if ret != 0 {
                 return Err(PyRuntimeError::new_err("mprotect(PROT_READ) failed in write() exit"));
@@ -334,7 +386,7 @@ struct ReadGuard {
 impl ReadGuard {
     fn __enter__<'py>(slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArray1<f64> {
         let cell = slf.node.as_ref(py).borrow();
-        let dims: [npy_intp; 1] = [10];
+        let dims: [npy_intp; 1] = [cell.len as npy_intp];
         let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
@@ -357,7 +409,7 @@ impl ReadGuard {
     fn __exit__(&mut self, _t: &PyAny, _v: &PyAny, _tb: &PyAny) -> PyResult<()> {
         Python::with_gil(|py| {
             let cell = self.node.as_ref(py).borrow();
-            let len = cell.state.0.len();
+            let len = cell.state.0.byte_len();
             let ret = unsafe { mprotect(cell.state.0.mm.as_ptr() as *mut _, len, PROT_READ | PROT_WRITE) };
             if ret != 0 {
                 return Err(PyRuntimeError::new_err("mprotect(PROT_READ|WRITE) failed in read() exit"));
@@ -368,9 +420,11 @@ impl ReadGuard {
 }
 
 #[pyfunction]
-#[pyo3(signature = (name, listen, peers))]
-fn start(py: Python<'_>, name: &str, listen: &str, peers: Vec<&str>) -> PyResult<Node> {
-    let buf = MmapBuf::new().map_err(|e| PyValueError::new_err(e.to_string()))?;
+#[pyo3(signature = (name, listen, peers, shape=None))]
+fn start(_py: Python<'_>, name: &str, listen: &str, peers: Vec<&str>, shape: Option<Vec<usize>>) -> PyResult<Node> {
+    let shape = shape.unwrap_or_else(|| vec![10]);
+    let len: usize = shape.iter().product();
+    let buf = MmapBuf::new(shape.clone()).map_err(|e| PyValueError::new_err(e.to_string()))?;
     let state = Shared(Arc::new(buf));
     let (tx, rx) = async_channel::bounded(1024);
 
@@ -383,15 +437,15 @@ fn start(py: Python<'_>, name: &str, listen: &str, peers: Vec<&str>) -> PyResult
     RUNTIME.spawn(broadcaster(peer_addrs, rx));
 
     unsafe {
-        let len0 = state.0.len();
+        let len0 = state.0.byte_len();
         let ret = mprotect(state.0.mm.as_ptr() as *mut _, len0, PROT_READ);
         if ret != 0 {
             return Err(PyRuntimeError::new_err("mprotect(PROT_READ) failed in start()"));
         }
     }
 
-    println!("node {} running on {}", name, listen);
-    Ok(Node { name: name.to_string(), state, tx })
+    println!("node {} running on {} with shape {:?}", name, listen, shape);
+    Ok(Node { name: name.to_string(), state, tx, shape, len })
 }
 
 // ---------- module init ----------------------------------------------------


### PR DESCRIPTION
## Summary
- allow custom array shape when starting node
- send shape alongside array updates
- check update shape matches local shape on reception

## Testing
- `cargo build --release`
- `maturin develop --release` *(fails: no virtualenv)*

------
https://chatgpt.com/codex/tasks/task_e_683faacedba88332a6bf822ca82b5844