### PR TITLE
Integrate openraft cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,7 @@ dependencies = [
  "maplit",
  "openraft-macros",
  "rand",
+ "serde",
  "thiserror",
  "tokio",
  "tracing",
@@ -759,6 +760,19 @@ dependencies = [
  "quote",
  "semver",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "openraft-memstore"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77fc15f7e276324bfdb068d7596c0c74ed485c3dbe9cea3a657249acfeed7ef"
+dependencies = [
+ "openraft",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -958,6 +972,7 @@ dependencies = [
  "numpy",
  "once_cell",
  "openraft",
+ "openraft-memstore",
  "parking_lot",
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-channel = "1"   # used in lib.rs for the broadcast queue
 memmap2     = "0.9"
 libc        = "0.2"
 openraft = "0.9.18"
+openraft-memstore = "0.9.18"
 
 [build-dependencies]
 pyo3-build-config = "0.20"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,13 @@ use std::io::ErrorKind;
 use std::sync::Arc;
 use std::os::raw::{c_int, c_void};
 
+use openraft::{Config, Raft, AnyError};
+use openraft::error::{RPCError, RaftError, Unreachable, InstallSnapshotError};
+use openraft::network::{RaftNetwork, RaftNetworkFactory, RPCOption};
+use openraft::storage::Adaptor;
+use openraft_memstore::MemStore;
+
+
 // ---------- global Tokio runtime (one per process) -------------------------
 static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("tokio"));
 
@@ -106,6 +113,48 @@ impl Update {
             buf.extend_from_slice(&v.to_le_bytes());
         }
         buf
+    }
+}
+
+// ---------- raft network ----------------------------------------------------
+
+#[derive(Clone, Default)]
+struct DummyNetwork;
+
+impl RaftNetwork<openraft_memstore::TypeConfig> for DummyNetwork {
+    async fn append_entries(
+        &mut self,
+        _rpc: openraft::raft::AppendEntriesRequest<openraft_memstore::TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<openraft::raft::AppendEntriesResponse<u64>, RPCError<u64, (), RaftError<u64>>> {
+        Err(RPCError::Unreachable(Unreachable::new(&AnyError::error("no network"))))
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        _rpc: openraft::raft::InstallSnapshotRequest<openraft_memstore::TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<openraft::raft::InstallSnapshotResponse<u64>, RPCError<u64, (), RaftError<u64, InstallSnapshotError>>> {
+        Err(RPCError::Unreachable(Unreachable::new(&AnyError::error("no network"))))
+    }
+
+    async fn vote(
+        &mut self,
+        _rpc: openraft::raft::VoteRequest<u64>,
+        _option: RPCOption,
+    ) -> Result<openraft::raft::VoteResponse<u64>, RPCError<u64, (), RaftError<u64>>> {
+        Err(RPCError::Unreachable(Unreachable::new(&AnyError::error("no network"))))
+    }
+}
+
+#[derive(Clone, Default)]
+struct DummyFactory;
+
+impl RaftNetworkFactory<openraft_memstore::TypeConfig> for DummyFactory {
+    type Network = DummyNetwork;
+
+    async fn new_client(&mut self, _target: u64, _node: &()) -> Self::Network {
+        DummyNetwork
     }
 }
 
@@ -233,6 +282,7 @@ struct Node {
     tx: async_channel::Sender<Update>,
     shape: Vec<usize>,
     len: usize,
+    raft: Raft<openraft_memstore::TypeConfig>,
 }
 
 #[pymethods]
@@ -407,7 +457,29 @@ fn start(_py: Python<'_>, name: &str, listen: &str, peers: Vec<&str>, shape: Opt
 
     let listen_addr: SocketAddr = listen.parse()
         .map_err(|e: std::net::AddrParseError| PyValueError::new_err(e.to_string()))?;
-    let peer_addrs: Vec<SocketAddr> = peers.into_iter().filter_map(|p| p.parse().ok()).collect();
+    let peer_addrs: Vec<SocketAddr> = peers.iter().filter_map(|p| p.parse().ok()).collect();
+
+    // setup raft
+    let node_id = listen_addr.port() as u64;
+    let mut members = std::collections::BTreeSet::new();
+    members.insert(node_id);
+    for p in &peer_addrs {
+        members.insert(p.port() as u64);
+    }
+
+    let raft = RUNTIME.block_on(async {
+        let cfg = Arc::new(Config::default().validate().unwrap());
+        let store = Arc::new(MemStore::new());
+        let (log_store, sm_store) = Adaptor::<openraft_memstore::TypeConfig, _>::new(store);
+        let network = DummyFactory::default();
+        let r = Raft::new(node_id, cfg.clone(), network, log_store, sm_store)
+            .await
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        if let Err(e) = r.initialize(members).await {
+            eprintln!("raft init error: {}", e);
+        }
+        Ok::<_, PyErr>(r)
+    })?;
 
     let st_clone = state.clone();
     RUNTIME.spawn(listener(listen_addr, st_clone));
@@ -422,7 +494,7 @@ fn start(_py: Python<'_>, name: &str, listen: &str, peers: Vec<&str>, shape: Opt
     }
 
     println!("node {} running on {} with shape {:?}", name, listen, shape);
-    Ok(Node { name: name.to_string(), state, tx, shape, len })
+    Ok(Node { name: name.to_string(), state, tx, shape, len, raft })
 }
 
 // ---------- module init ----------------------------------------------------


### PR DESCRIPTION
## Summary
- include `openraft-memstore` and initialize a Raft cluster when creating a node
- provide dummy Raft network implementation
- store Raft instance in the `Node` struct

## Testing
- `cargo check`
- `maturin develop --release` *(fails: couldn't find a virtualenv)*

------
https://chatgpt.com/codex/tasks/task_e_6840f5fe89f483328f8ddc6c707e8dee