### PR TITLE
Add server/client support with update callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +394,7 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -419,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +455,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3        = { version = "0.20", features = ["extension-module", "auto-initialize"] }
 numpy       = "0.20"
-tokio       = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
+tokio       = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
 anyhow      = "1"
 parking_lot = "0.12"
 once_cell   = "1"
@@ -23,6 +23,7 @@ async-channel = "1"   # used in lib.rs for the broadcast queue
 memmap2     = "0.9"
 libc        = "0.2"
 serde = "1.0.219"
+serde_json = "1.0"
 
 [build-dependencies]
 pyo3-build-config = "0.20"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,9 @@ use std::{
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
+    net::TcpStream,
     runtime::{Builder, Runtime},
+    sync::Mutex,
 };
 
 // ---------- Tokio runtime (shared) ------------------------------------
@@ -29,18 +30,28 @@ static RT: Lazy<Runtime> = Lazy::new(|| {
 // ---------- shared mmap buffer ----------------------------------------
 struct MmapBuf {
     mm: MmapMut,
+    shape: Vec<usize>,
+    len: usize,
 }
 
 impl MmapBuf {
-    fn new() -> Result<Self> {
-        // We only need to hold 10 f64s (80 bytes), no page-align requirement here.
-        let layout = 10 * std::mem::size_of::<f64>();
+    fn new(shape: Vec<usize>) -> Result<Self> {
+        let len: usize = shape.iter().product();
+        let layout = len * std::mem::size_of::<f64>();
         let mm = MmapOptions::new().len(layout).map_anon()?;
-        Ok(Self { mm })
+        Ok(Self { mm, shape, len })
     }
 
     fn ptr(&self) -> *mut c_void {
         self.mm.as_ptr() as *mut _
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
     }
 }
 
@@ -48,53 +59,26 @@ impl MmapBuf {
 struct Shared(Arc<MmapBuf>);
 
 // ---------- wire format -----------------------------------------------
-struct Full {
-    vals: Vec<f64>,
-}
-
 // ---------- networking helpers ----------------------------------------
-async fn handle_peer(mut sock: TcpStream, shared: Shared) -> Result<()> {
-    let len = shared.0.mm.len();
-
-    loop {
-        // A mutable view onto this process’ own mmap:
-        let dst: &mut [u8] = unsafe {
-            std::slice::from_raw_parts_mut(shared.0.mm.as_ptr() as *mut u8, len)
-        };
-
-        // read_exact fills the mmap slice in-place – no intermediate buffer.
-        if sock.read_exact(dst).await.is_err() {
-            break;       // peer closed
-        }
-    }
-    Ok(())
-}
-
-
-async fn listener(listener: TcpListener, shared: Shared) -> Result<()> {
-    loop {
-        let (sock, _) = listener.accept().await?;
-        let shared2 = shared.clone();
-        tokio::spawn(async move {
-            let _ = handle_peer(sock, shared2).await;
-        });
-    }
-}
 
 // ---------- Python bindings -------------------------------------------
 #[pyclass]
 struct Node {
     shared: Shared,
-    peers: Vec<SocketAddr>,
+    mode: NodeMode,
+}
+
+enum NodeMode {
+    Server { clients: Arc<tokio::sync::Mutex<Vec<TcpStream>>> },
+    Client { addr: SocketAddr, on_update: Option<Py<PyAny>> },
 }
 
 #[pymethods]
 impl Node {
-    /// Return a numpy.ndarray\<f64\> view of our shared buffer (length 10).
+    /// Return a numpy.ndarray\<f64\> view of our shared buffer.
     #[getter]
     fn ndarray<'py>(slf: PyRef<'py, Node>, py: Python<'py>) -> &'py PyArray1<f64> {
-        // We expose a 1‐D array of length 10.
-        let dims: [npy_intp; 1] = [10];
+        let dims: [npy_intp; 1] = [slf.shared.0.len() as npy_intp];
         let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
 
         unsafe {
@@ -128,7 +112,7 @@ impl Node {
                 return Err(PyRuntimeError::new_err("mprotect(PROT_READ|WRITE) failed in write()"));
             }
         }
-        Ok(WriteGuard { node: slf.into() })
+        Ok(WriteGuard { node: slf.into(), data: None })
     }
 
     /// Begin a read context: updates are blocked until exit.
@@ -145,16 +129,8 @@ impl Node {
 
     /// Manual flush helper if the user wants to push immediately.
     fn flush(&self) -> PyResult<()> {
-        flush_now(self);
+        flush_now(self, Vec::new());
         Ok(())
-    }
-    /// Construct a new Node by binding to `listen` and connecting to `peers`.
-    #[new]
-    fn new(listen: String, peers: Vec<String>) -> PyResult<Self> {
-        Python::with_gil(|py| {
-            let peer_slices: Vec<&str> = peers.iter().map(String::as_str).collect();
-            start(py, &listen, peer_slices)
-        })
     }
 }
 
@@ -162,111 +138,164 @@ impl Node {
 /// Start a new Node that listens on `listen` (and immediately spawns a Tokio task for it)
 /// and also knows how to broadcast to the given `peers`.
 #[pyfunction]
-fn start(_py: Python<'_>, listen: &str, peers: Vec<&str>) -> PyResult<Node> {
-    // 1) Create an anonymous mmap for 10 f64s:
-    let buf = MmapBuf::new().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+#[pyo3(signature = (name, listen=None, server=None, shape=None, on_update=None))]
+pub fn start(
+    py: Python<'_>,
+    name: &str,
+    listen: Option<&str>,
+    server: Option<&str>,
+    shape: Option<Vec<usize>>,
+    on_update: Option<PyObject>,
+) -> PyResult<Node> {
+    let shape = shape.unwrap_or_else(|| vec![10]);
+    let _ = name;
+    let buf = MmapBuf::new(shape).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     let shared = Shared(Arc::new(buf));
 
-    // 2) Parse each peer address as SocketAddr:
-    let peer_addrs: Vec<SocketAddr> = peers
-        .into_iter()
-        .filter_map(|p| p.parse().ok())
-        .collect();
-
-
-    // 3) Make mmap read-only until a write() context, then bind the listener:
-    let len0 = shared.0.mm.len();
     unsafe {
-        let ret = mprotect(shared.0.mm.as_ptr() as *mut _, len0, PROT_READ);
+        let ret = mprotect(shared.0.mm.as_ptr() as *mut _, shared.0.mm.len(), PROT_READ);
         if ret != 0 {
             return Err(PyRuntimeError::new_err("mprotect(PROT_READ) failed in start()"));
         }
     }
-    // Bind the listener synchronously so EADDRINUSE pops up at import time:
-    // …bind std_listener…
-    let std_listener = std::net::TcpListener::bind(listen)
-        .map_err(|e| PyRuntimeError::new_err(format!("bind {listen}: {e}")))?;
-    std_listener.set_nonblocking(true)
-        .map_err(|e| PyRuntimeError::new_err(format!("non-blocking: {e}")))?;
 
-    // — Remove the semicolon at the end, and move `?` outside the closure:
-    let tokio_listener = {
-        let _g = RT.enter();
-        tokio::net::TcpListener::from_std(std_listener)
-            .map_err(|e| PyRuntimeError::new_err(format!("to-tokio: {e}")))?
-    };
-
-    let shared2 = shared.clone();
-    RT.spawn(async move {
-        if let Err(e) = listener(tokio_listener, shared2).await {
-            eprintln!("raftmem listener error: {e}");
-        }
-    });
-
-    println!("raftmem: started on {}", listen);
-    Ok(Node {
-        shared,
-        peers: peer_addrs,
-    })
-}
-
-async fn broadcast_raw(peers: &[SocketAddr], shared: Shared) {
-    // Unsafe is just to cast the mmap pointer to a byte slice.
-    let bytes: &[u8] = unsafe {
-        std::slice::from_raw_parts(shared.0.mm.as_ptr(), shared.0.mm.len())
-    };
-
-    for &addr in peers {
-        if let Ok(mut s) = TcpStream::connect(addr).await {
-            let _ = s.write_all(bytes).await;      // <-- write the mmap slice itself
-        }
+    if let Some(addr_str) = listen {
+        let addr: SocketAddr = addr_str
+            .parse::<SocketAddr>()
+            .map_err(|e: std::net::AddrParseError| PyRuntimeError::new_err(e.to_string()))?;
+        let std_listener = std::net::TcpListener::bind(addr)
+            .map_err(|e| PyRuntimeError::new_err(format!("bind {addr}: {e}")))?;
+        std_listener.set_nonblocking(true)
+            .map_err(|e| PyRuntimeError::new_err(format!("non-blocking: {e}")))?;
+        let tokio_listener = {
+            let _g = RT.enter();
+            tokio::net::TcpListener::from_std(std_listener)
+                .map_err(|e| PyRuntimeError::new_err(format!("to-tokio: {e}")))?
+        };
+        let clients = Arc::new(Mutex::new(Vec::new()));
+        let clients2 = clients.clone();
+        RT.spawn(async move {
+            loop {
+                if let Ok((sock, _)) = tokio_listener.accept().await {
+                    clients2.lock().await.push(sock);
+                }
+            }
+        });
+        println!("raftmem: server running on {}", addr);
+        Ok(Node { shared, mode: NodeMode::Server { clients } })
+    } else if let Some(addr_str) = server {
+        let addr: SocketAddr = addr_str
+            .parse::<SocketAddr>()
+            .map_err(|e: std::net::AddrParseError| PyRuntimeError::new_err(e.to_string()))?;
+        let cb = on_update.map(|o| o.into_py(py));
+        let shared2 = shared.clone();
+        let cb2 = cb.clone();
+        RT.spawn(async move {
+            loop {
+                match TcpStream::connect(addr).await {
+                    Ok(mut sock) => {
+                        let len = shared2.0.mm.len();
+                        let mut buf = vec![0u8; len];
+                        loop {
+                            if sock.read_exact(&mut buf).await.is_err() {
+                                break;
+                            }
+                            unsafe { mprotect(shared2.0.mm.as_ptr() as *mut _, len, PROT_READ | PROT_WRITE); }
+                            unsafe {
+                                std::ptr::copy_nonoverlapping(
+                                    buf.as_ptr(),
+                                    shared2.0.mm.as_ptr() as *mut u8,
+                                    len,
+                                );
+                            }
+                            unsafe { mprotect(shared2.0.mm.as_ptr() as *mut _, len, PROT_READ); }
+                            let mut len_buf = [0u8; 4];
+                            if sock.read_exact(&mut len_buf).await.is_err() {
+                                break;
+                            }
+                            let dlen = u32::from_le_bytes(len_buf) as usize;
+                            let mut data = vec![0u8; dlen];
+                            if sock.read_exact(&mut data).await.is_err() {
+                                break;
+                            }
+                            if let Some(cb) = &cb2 {
+                                Python::with_gil(|py| {
+                                    if let Ok(json) = py.import("json") {
+                                        if let Ok(loads) = json.getattr("loads") {
+                                            if let Ok(obj) = loads.call1((String::from_utf8_lossy(&data).to_string(),)) {
+                                                let _ = cb.call1(py, (obj,));
+                                            }
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("connect error: {}", e);
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
+                }
+            }
+        });
+        println!("raftmem: client connected to {}", addr);
+        Ok(Node { shared, mode: NodeMode::Client { addr, on_update: cb } })
+    } else {
+        Err(PyRuntimeError::new_err("either listen or server must be provided"))
     }
 }
 
-// ---------- helper -----------------------------------------------------
-fn flush_now(node: &Node) {
-    let peers  = node.peers.clone();
-    let shared = node.shared.clone();          // keep the mmap alive for the async task
+async fn broadcast_raw(clients: Arc<Mutex<Vec<TcpStream>>>, shared: Shared, data: Vec<u8>) {
+    let bytes: &[u8] = unsafe { std::slice::from_raw_parts(shared.0.mm.as_ptr(), shared.0.mm.len()) };
+    let mut conns = {
+        let mut g = clients.lock().await;
+        std::mem::take(&mut *g)
+    };
+    let mut alive = Vec::new();
+    for mut s in conns.drain(..) {
+        let mut ok = true;
+        if s.write_all(bytes).await.is_err() { ok = false; }
+        if ok {
+            let len = data.len() as u32;
+            if s.write_all(&len.to_le_bytes()).await.is_err() { ok = false; }
+        }
+        if ok && s.write_all(&data).await.is_err() { ok = false; }
+        if ok { alive.push(s); }
+    }
+    clients.lock().await.extend(alive);
+}
 
-    RT.spawn(async move {
-        broadcast_raw(&peers, shared).await;
-    });
+// ---------- helper -----------------------------------------------------
+fn flush_now(node: &Node, data: Vec<u8>) {
+    if let NodeMode::Server { clients } = &node.mode {
+        let clients = clients.clone();
+        let shared = node.shared.clone();
+        RT.spawn(async move { broadcast_raw(clients, shared, data).await; });
+    }
 }
 
 #[pyclass]
 struct WriteGuard {
     node: Py<Node>,
+    data: Option<PyObject>,
 }
 
 #[pymethods]
 impl WriteGuard {
-    fn __enter__<'py>(slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArray1<f64> {
-        let cell = slf.node.as_ref(py).borrow();
-        // Return a writable ndarray view.
-        let dims: [npy_intp; 1] = [10];
-        let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
-        unsafe {
-            let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
-            let descr = <f64 as Element>::get_dtype(py).into_dtype_ptr();
-            let arr_ptr = PY_ARRAY_API.PyArray_NewFromDescr(
-                py,
-                subtype,
-                descr,
-                dims.len() as c_int,
-                dims.as_ptr() as *mut npy_intp,
-                strides.as_ptr() as *mut npy_intp,
-                cell.shared.0.ptr(),
-                NPY_ARRAY_WRITEABLE,
-                cell.as_ptr(),
-            );
-            PyArray1::from_owned_ptr(py, arr_ptr)
-        }
+    fn __enter__(slf: PyRefMut<'_, Self>) -> PyRefMut<'_, Self> {
+        slf
     }
 
     fn __exit__(&mut self, _t: &PyAny, _v: &PyAny, _tb: &PyAny) -> PyResult<()> {
         Python::with_gil(|py| {
             let cell = self.node.as_ref(py).borrow();
-            flush_now(&*cell);
+            let data = if let Some(d) = self.data.take() {
+                let json = py.import("json")?;
+                let dumps = json.getattr("dumps")?;
+                let s: String = dumps.call1((d,))?.extract()?;
+                s.into_bytes()
+            } else { Vec::new() };
+            flush_now(&*cell, data);
             let len = cell.shared.0.mm.len();
             let ret = unsafe { mprotect(cell.shared.0.mm.as_ptr() as *mut _, len, PROT_READ) };
             if ret != 0 {
@@ -274,6 +303,20 @@ impl WriteGuard {
             }
             Ok(())
         })
+    }
+
+    fn __setitem__(&mut self, idx: usize, value: f64) {
+        Python::with_gil(|py| {
+            let cell = self.node.as_ref(py).borrow();
+            unsafe {
+                let base = cell.shared.0.mm.as_ptr() as *mut f64;
+                *base.add(idx) = value;
+            }
+        });
+    }
+
+    fn update(&mut self, obj: PyObject) {
+        self.data = Some(obj);
     }
 }
 
@@ -287,7 +330,7 @@ impl ReadGuard {
     fn __enter__<'py>(slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArray1<f64> {
         let cell = slf.node.as_ref(py).borrow();
         // Return a read-only ndarray view.
-        let dims: [npy_intp; 1] = [10];
+        let dims: [npy_intp; 1] = [cell.shared.0.len() as npy_intp];
         let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);


### PR DESCRIPTION
## Summary
- expand `start()` to handle server/client roles and optional callbacks
- track connections and broadcast updates with payloads
- support dynamic mmap length
- expose write guard update and item-setting helpers

## Testing
- `cargo check`
- `maturin develop --release`

------
https://chatgpt.com/codex/tasks/task_e_68410ccba2ec8332b35df0f238abf370