### PR TITLE
Add update event and mean calc in ticker client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Ticker plant examples have been added under `examples/ticker_plant.py` and
+`examples/ticker_client.py`.  The client now computes the mean price for each
+ticker whenever new data arrives.

--- a/examples/ticker_client.py
+++ b/examples/ticker_client.py
@@ -1,0 +1,44 @@
+import argparse
+import time
+from threading import Event
+import numpy as np
+import raftmem
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--server', default='0.0.0.0:7010')
+parser.add_argument('--tickers', default='AAPL,MSFT,GOOG')
+parser.add_argument('--rows', type=int, default=1000)
+args = parser.parse_args()
+
+symbols = args.tickers.split(',')
+num_tickers = len(symbols)
+num_rows = args.rows
+
+update_event = Event()
+
+
+def on_update(data):
+    symbol = data.get('symbol')
+    row = data.get('row')
+    if symbol is not None and row is not None:
+        try:
+            idx = symbols.index(symbol)
+        except ValueError:
+            print('unknown symbol', symbol)
+        else:
+            price = arr[row, idx]
+            print(f"{symbol} row {row}: {price}")
+    else:
+        print('update', data)
+    update_event.set()
+
+arr = None  # will hold ndarray view once node is started
+node = raftmem.start('client', server=args.server, shape=[num_rows * num_tickers], on_update=on_update)
+arr = node.ndarray.reshape(num_rows, num_tickers)
+
+while True:
+    update_event.wait()
+    update_event.clear()
+    with node.read():
+        means = np.mean(arr, axis=0)
+    print({sym: m for sym, m in zip(symbols, means)})

--- a/examples/ticker_plant.py
+++ b/examples/ticker_plant.py
@@ -1,0 +1,34 @@
+import argparse
+import random
+import time
+import numpy as np
+import raftmem
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--listen', default='0.0.0.0:7010')
+parser.add_argument('--tickers', default='AAPL,MSFT,GOOG')
+parser.add_argument('--rows', type=int, default=1000)
+args = parser.parse_args()
+
+symbols = args.tickers.split(',')
+num_tickers = len(symbols)
+num_rows = args.rows
+
+# shared buffer sized for rows * tickers
+node = raftmem.start('tp', listen=args.listen, shape=[num_rows * num_tickers])
+arr = node.ndarray.reshape(num_rows, num_tickers)
+
+# position for each ticker column
+positions = [0 for _ in range(num_tickers)]
+
+while True:
+    # simulate tick for random ticker
+    sym_index = random.randrange(num_tickers)
+    price = random.random() * 100
+
+    row = positions[sym_index]
+    with node.write() as a:
+        a[row * num_tickers + sym_index] = price
+        positions[sym_index] = (row + 1) % num_rows
+        a.update({'positions': positions, 'symbol': symbols[sym_index], 'row': row})
+    time.sleep(0.1)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,9 +77,22 @@ enum NodeMode {
 impl Node {
     /// Return a numpy.ndarray\<f64\> view of our shared buffer.
     #[getter]
-    fn ndarray<'py>(slf: PyRef<'py, Node>, py: Python<'py>) -> &'py PyArray1<f64> {
-        let dims: [npy_intp; 1] = [slf.shared.0.len() as npy_intp];
-        let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
+    fn ndarray<'py>(slf: PyRef<'py, Node>, py: Python<'py>) -> PyResult<&'py PyAny> {
+        let shape: Vec<npy_intp> = slf
+            .shared
+            .0
+            .shape()
+            .iter()
+            .map(|&d| d as npy_intp)
+            .collect();
+
+        let mut strides: Vec<npy_intp> = vec![0; shape.len()];
+        if !shape.is_empty() {
+            strides[shape.len() - 1] = std::mem::size_of::<f64>() as npy_intp;
+            for i in (0..shape.len() - 1).rev() {
+                strides[i] = strides[i + 1] * shape[i + 1];
+            }
+        }
 
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
@@ -88,14 +101,14 @@ impl Node {
                 py,
                 subtype,
                 descr,
-                dims.len() as c_int,
-                dims.as_ptr() as *mut npy_intp,
+                shape.len() as c_int,
+                shape.as_ptr() as *mut npy_intp,
                 strides.as_ptr() as *mut npy_intp,
                 slf.shared.0.ptr(),
                 NPY_ARRAY_WRITEABLE,
                 slf.as_ptr(),
             );
-            PyArray1::from_owned_ptr(py, arr_ptr)
+            Ok(py.from_owned_ptr(arr_ptr))
         }
     }
 


### PR DESCRIPTION
## Summary
- merge main into work
- compute per-ticker mean in the client when updates arrive
- document ticker examples in README

## Testing
- `maturin develop --release` *(fails: Couldn't find a virtualenv)*
- `python examples/ticker_plant.py --rows 10 --tickers AAPL,MSFT --listen 127.0.0.1:9999` *(failed: ModuleNotFoundError)*
- `python examples/ticker_client.py --server 127.0.0.1:9999 --rows 10 --tickers AAPL,MSFT` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6841233236448332a226c14814da08cc