### PR TITLE
Add WAL with compression and leader callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +977,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "libc",
+ "lz4_flex",
  "memmap2",
  "numpy",
  "once_cell",
@@ -1190,6 +1200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1363,16 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ memmap2     = "0.9"
 libc        = "0.2"
 openraft = "0.9.18"
 openraft-memstore = "0.9.18"
+lz4_flex = "0.11"
 
 [build-dependencies]
 pyo3-build-config = "0.20"

--- a/examples/client_a.py
+++ b/examples/client_a.py
@@ -10,6 +10,7 @@ parser.add_argument('--peers', nargs='+', default=['0.0.0.0:7011', '0.0.0.0:7012
 args = parser.parse_args()
 
 node = raftmem.start("a", args.listen, args.peers, shape=[10,10])
+node.set_on_leader(lambda: print("A became leader"))
 
 while True:
     with node.write() as a:

--- a/examples/client_b.py
+++ b/examples/client_b.py
@@ -10,6 +10,7 @@ parser.add_argument('--peers', nargs='+', default=['0.0.0.0:7010', '0.0.0.0:7012
 args = parser.parse_args()
 
 node = raftmem.start("b", args.listen, args.peers, shape=[10,10])
+node.set_on_leader(lambda: print("B became leader"))
 
 while True:
     with node.read() as arr:

--- a/examples/client_c.py
+++ b/examples/client_c.py
@@ -10,6 +10,7 @@ parser.add_argument('--peers', nargs='+', default=['0.0.0.0:7010', '0.0.0.0:7011
 args = parser.parse_args()
 
 node = raftmem.start("c", args.listen, args.peers, shape=[10,10])
+node.set_on_leader(lambda: print("C became leader"))
 
 while True:
     with node.read() as arr:


### PR DESCRIPTION
## Summary
- support LZ4 compression via `lz4_flex`
- implement a simple WAL written on every flush and when receiving peer data
- compress WAL on a timer
- expose `set_on_leader` Python callback using Raft metrics
- clients now register a leader callback

## Testing
- `maturin develop --release`

------
https://chatgpt.com/codex/tasks/task_e_684237569f788332acb9f63a0de2accd