### PR TITLE
Replace RwLock with seqlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,6 @@ dependencies = [
  "memmap2",
  "numpy",
  "once_cell",
- "parking_lot",
  "pyo3",
  "pyo3-build-config",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ pyo3        = { version = "0.20", features = ["extension-module", "auto-initiali
 numpy       = "0.20"
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 anyhow      = "1"
-parking_lot = "0.12"
 once_cell   = "1"
 async-channel = "1"   # used in lib.rs for the broadcast queue
 memmap2     = "0.9"


### PR DESCRIPTION
## Summary
- use an atomic sequence counter instead of a `RwLock`
- update reader to copy under seqlock logic
- update writer and network writes to increment the sequence
- drop `parking_lot` dependency

## Testing
- `pip install -r requirements.txt`
- `maturin develop --release`
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_684322fbf97883328d757c9f493057dd