### PR TITLE
Refactor handle_peer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,262 +1,23 @@
-use anyhow::Result;
-use memmap2::{MmapMut, MmapOptions};
-use libc::{mprotect, PROT_READ, PROT_WRITE};
+mod memory;
+mod net;
+
+use memory::{MmapBuf, Shared};
+use net::{broadcaster, listener, Update};
+
 use once_cell::sync::Lazy;
-use std::cell::RefCell;
-use numpy::{Element, PyArray1};
-use numpy::npyffi::{PY_ARRAY_API, NpyTypes, NPY_ARRAY_WRITEABLE, npy_intp};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
-use pyo3::exceptions::PyRuntimeError;
-use pyo3::exceptions::PyValueError;
-use std::sync::atomic::{AtomicUsize, Ordering, fence};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use numpy::{Element, PyArray1};
+use numpy::npyffi::{PY_ARRAY_API, NpyTypes, NPY_ARRAY_WRITEABLE, npy_intp};
+use std::cell::RefCell;
+use tokio::runtime::Runtime;
 use std::net::SocketAddr;
-use tokio::{net::{TcpListener, TcpStream}, runtime::Runtime};
-use std::io::ErrorKind;
-use std::sync::Arc;
 use std::os::raw::{c_int, c_void};
+use libc::{PROT_READ};
 
-// ---------- global Tokio runtime (one per process) -------------------------
 static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("tokio"));
 
-// ---------- in‑memory state -------------------------------------------------
-struct MmapBuf {
-    mm: MmapMut,
-    shape: Vec<usize>,
-}
-
-impl MmapBuf {
-    fn new(shape: Vec<usize>) -> Result<Self> {
-        let len: usize = shape.iter().product();
-        let layout = len * std::mem::size_of::<f64>();
-        let mm = MmapOptions::new().len(layout).map_anon()?;
-        Ok(Self { mm, shape })
-    }
-
-    fn ptr(&self) -> *mut c_void {
-        self.mm.as_ptr() as *mut _
-    }
-
-    fn byte_len(&self) -> usize {
-        self.mm.len()
-    }
-
-    fn shape(&self) -> &[usize] {
-        &self.shape
-    }
-}
-
-#[derive(Clone)]
-struct Shared {
-    mm: Arc<MmapBuf>,
-    seq: Arc<AtomicUsize>,    // sequence counter for seqlock
-}
-
-impl Shared {
-    fn new(mm: MmapBuf) -> Self {
-        Self { mm: Arc::new(mm), seq: Arc::new(AtomicUsize::new(0)) }
-    }
-
-    fn get(&self, idx: usize) -> f64 {
-        unsafe {
-            let base = self.mm.mm.as_ptr() as *const f64;
-            *base.add(idx)
-        }
-    }
-
-    fn shape(&self) -> &[usize] {
-        self.mm.shape()
-    }
-}
-
-// ---------- wire protocol ---------------------------------------------------
-#[derive(Debug, Clone)]
-struct Update {
-    shape: Vec<u32>,
-    start: u32,
-    vals: Vec<f64>,
-}
-
-impl Update {
-    fn to_bytes(&self) -> Vec<u8> {
-        let shape_len = self.shape.len() as u32;
-        let val_len = self.vals.len() as u32;
-        let mut buf = Vec::with_capacity(4 + self.shape.len() * 4 + 4 + 4 + self.vals.len() * 8);
-        buf.extend_from_slice(&shape_len.to_le_bytes());
-        for d in &self.shape {
-            buf.extend_from_slice(&d.to_le_bytes());
-        }
-        buf.extend_from_slice(&self.start.to_le_bytes());
-        buf.extend_from_slice(&val_len.to_le_bytes());
-        for v in &self.vals {
-            buf.extend_from_slice(&v.to_le_bytes());
-        }
-        buf
-    }
-}
-
-async fn handle_peer(mut sock: TcpStream, state: Shared) -> Result<()> {
-    let addr = sock.peer_addr().ok();
-    println!("peer {:?} connected", addr);
-    let local_shape = state.shape().to_vec();
-    let _local_bytes = state.mm.byte_len();
-
-    loop {
-        // read the remote array shape
-        let mut shape_len_buf = [0u8; 4];
-        match sock.read_exact(&mut shape_len_buf).await {
-            Ok(_) => {}
-            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
-            Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
-            Err(e) => return Err(e.into()),
-        }
-        let shape_len = u32::from_le_bytes(shape_len_buf) as usize;
-
-        let mut shape_bytes = vec![0u8; shape_len * 4];
-        match sock.read_exact(&mut shape_bytes).await {
-            Ok(_) => {}
-            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
-            Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
-            Err(e) => return Err(e.into()),
-        }
-
-        let mut shape = Vec::with_capacity(shape_len);
-        for i in 0..shape_len {
-            let mut d = [0u8; 4];
-            d.copy_from_slice(&shape_bytes[i * 4..(i + 1) * 4]);
-            shape.push(u32::from_le_bytes(d) as usize);
-        }
-
-        let len: usize = shape.iter().product();
-
-        // read start index and value length
-        let mut start_buf = [0u8; 4];
-        match sock.read_exact(&mut start_buf).await {
-            Ok(_) => {}
-            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
-            Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
-            Err(e) => return Err(e.into()),
-        }
-        let start_idx = u32::from_le_bytes(start_buf) as usize;
-
-        let mut val_len_buf = [0u8; 4];
-        match sock.read_exact(&mut val_len_buf).await {
-            Ok(_) => {}
-            Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
-            Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
-            Err(e) => return Err(e.into()),
-        }
-        let val_len = u32::from_le_bytes(val_len_buf) as usize;
-
-        if shape != local_shape {
-            println!("shape mismatch: recv {:?} local {:?}", shape, state.shape());
-            // discard incoming data
-            let mut discard = vec![0u8; val_len * 8];
-            match sock.read_exact(&mut discard).await {
-                Ok(_) => continue,
-                Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
-                Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
-                Err(e) => return Err(e.into()),
-            }
-        } else {
-            let mut vals_buf = vec![0u8; val_len * 8];
-            match sock.read_exact(&mut vals_buf).await {
-                Ok(_) => {}
-                Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => break,
-                Err(ref e) if e.kind() == ErrorKind::ConnectionReset => break,
-                Err(e) => return Err(e.into()),
-            }
-
-            let mut vals = Vec::with_capacity(val_len);
-            for i in 0..val_len {
-                let mut b = [0u8; 8];
-                b.copy_from_slice(&vals_buf[i * 8..(i + 1) * 8]);
-                vals.push(f64::from_le_bytes(b));
-            }
-
-            let len_bytes = state.mm.byte_len();
-            state.seq.fetch_add(1, Ordering::AcqRel);
-            unsafe { mprotect(state.mm.mm.as_ptr() as *mut _, len_bytes, PROT_READ | PROT_WRITE); }
-
-            let base = state.mm.mm.as_ptr() as *mut f64;
-            for (i, v) in (start_idx..start_idx + val_len).zip(vals.into_iter()) {
-                if i < len {
-                    unsafe { *base.add(i) = v; }
-                }
-            }
-
-            unsafe { mprotect(state.mm.mm.as_ptr() as *mut _, len_bytes, PROT_READ); }
-            state.seq.fetch_add(1, Ordering::Release);
-        }
-    }
-    println!("peer {:?} disconnected", addr);
-    Ok(())
-}
-
-async fn broadcaster(peers: Vec<SocketAddr>, rx: async_channel::Receiver<Update>) -> Result<()> {
-    let mut conns: Vec<(SocketAddr, TcpStream)> = Vec::new();
-    for p in &peers {
-        println!("connecting to peer {}", p);
-        match TcpStream::connect(*p).await {
-            Ok(s) => {
-                println!("connected to {}", p);
-                conns.push((*p, s));
-            }
-            Err(e) => println!("failed to connect to {}: {}", p, e),
-        }
-    }
-    while let Some(u) = rx.recv().await.ok() {
-        println!(
-            "broadcasting update shape {:?} start {} len {}",
-            u.shape,
-            u.start,
-            u.vals.len()
-        );
-        let data = u.to_bytes();
-
-        for p in &peers {
-            if !conns.iter().any(|(addr, _)| addr == p) {
-                println!("reconnecting to {}", p);
-                match TcpStream::connect(*p).await {
-                    Ok(s) => {
-                        println!("connected to {}", p);
-                        conns.push((*p, s));
-                    }
-                    Err(e) => println!("connect failed to {}: {}", p, e),
-                }
-            }
-        }
-
-        let mut alive = Vec::new();
-        for (addr, mut s) in conns {
-            match s.write_all(&data).await {
-                Ok(_) => {
-                    println!("sent to {}", addr);
-                    alive.push((addr, s));
-                }
-                Err(e) => {
-                    println!("send failed to {}: {}", addr, e);
-                }
-            }
-        }
-        conns = alive;
-    }
-    Ok(())
-}
-
-async fn listener(addr: SocketAddr, state: Shared) -> Result<()> {
-    println!("listening on {}", addr);
-    let lst = TcpListener::bind(addr).await?;
-    loop {
-        let (sock, peer) = lst.accept().await?;
-        println!("accepted connection from {}", peer);
-        let st = state.clone();
-        tokio::spawn(async move { let _ = handle_peer(sock, st).await; });
-    }
-}
-
-// ---------- exposed Python face -------------------------------------------
 #[pyclass]
 struct Node {
     name: String,
@@ -264,7 +25,7 @@ struct Node {
     tx: async_channel::Sender<Update>,
     shape: Vec<usize>,
     len: usize,
-    scratch: RefCell<Vec<f64>>, // reusable buffer for reads and diffing
+    scratch: RefCell<Vec<f64>>,
 }
 
 #[pymethods]
@@ -290,12 +51,12 @@ impl Node {
             PyArray1::from_owned_ptr(py, arr_ptr)
         }
     }
+
     fn flush(&self, _idx: usize) {
         let mut scratch = self.scratch.borrow_mut();
         if scratch.len() != self.len {
             scratch.resize(self.len, 0.0);
         }
-
         let mut start: Option<usize> = None;
         let mut end = 0usize;
         for i in 0..self.len {
@@ -308,7 +69,6 @@ impl Node {
                 scratch[i] = v;
             }
         }
-
         if let Some(s) = start {
             let vals = scratch[s..=end].to_vec();
             println!(
@@ -324,14 +84,7 @@ impl Node {
     }
 
     fn write<'py>(slf: PyRef<'py, Self>) -> PyResult<WriteGuard> {
-        let len = slf.state.mm.byte_len();
-        slf.state.seq.fetch_add(1, Ordering::AcqRel);
-        unsafe {
-            let ret = mprotect(slf.state.mm.mm.as_ptr() as *mut _, len, PROT_READ | PROT_WRITE);
-            if ret != 0 {
-                return Err(PyRuntimeError::new_err("mprotect(PROT_READ|WRITE) failed in write()"));
-            }
-        }
+        slf.state.start_write().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         Ok(WriteGuard { node: slf.into(), active: true })
     }
 
@@ -342,20 +95,7 @@ impl Node {
         if scratch.len() != slf.len {
             scratch.resize(slf.len, 0.0);
         }
-        loop {
-            let start = slf.state.seq.load(Ordering::Acquire);
-            if start % 2 == 1 { continue; }
-            fence(Ordering::Acquire);
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    slf.state.mm.mm.as_ptr() as *const f64,
-                    scratch.as_mut_ptr(),
-                    slf.len,
-                );
-            }
-            fence(Ordering::Acquire);
-            if slf.state.seq.load(Ordering::Relaxed) == start { break; }
-        }
+        slf.state.read_snapshot(&mut scratch);
         let data = std::mem::take(&mut *scratch);
         Ok(ReadGuard { node: node_ref, arr: Some(data) })
     }
@@ -399,13 +139,8 @@ impl WriteGuard {
         Python::with_gil(|py| {
             let cell = self.node.as_ref(py).borrow();
             flush_now(&*cell);
-            let len = cell.state.mm.byte_len();
-            let ret = unsafe { mprotect(cell.state.mm.mm.as_ptr() as *mut _, len, PROT_READ) };
-            if ret != 0 {
-                return Err(PyRuntimeError::new_err("mprotect(PROT_READ) failed in write() exit"));
-            }
-            cell.state.seq.fetch_add(1, Ordering::Release);
-            Ok(())
+            cell.state.end_write().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            PyResult::Ok(())
         })?;
         self.active = false;
         Ok(())
@@ -466,18 +201,11 @@ fn start(_py: Python<'_>, name: &str, listen: &str, peers: Vec<&str>, shape: Opt
         .map_err(|e: std::net::AddrParseError| PyValueError::new_err(e.to_string()))?;
     let peer_addrs: Vec<SocketAddr> = peers.iter().filter_map(|p| p.parse().ok()).collect();
 
-
     let st_clone = state.clone();
     RUNTIME.spawn(listener(listen_addr, st_clone));
     RUNTIME.spawn(broadcaster(peer_addrs, rx));
 
-    unsafe {
-        let len0 = state.mm.byte_len();
-        let ret = mprotect(state.mm.mm.as_ptr() as *mut _, len0, PROT_READ);
-        if ret != 0 {
-            return Err(PyRuntimeError::new_err("mprotect(PROT_READ) failed in start()"));
-        }
-    }
+    state.protect(PROT_READ).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
     println!("node {} running on {} with shape {:?}", name, listen, shape);
     Ok(Node {
@@ -490,7 +218,6 @@ fn start(_py: Python<'_>, name: &str, listen: &str, peers: Vec<&str>, shape: Opt
     })
 }
 
-// ---------- module init ----------------------------------------------------
 #[pymodule]
 fn raftmem(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<Node>()?;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,0 +1,97 @@
+use anyhow::Result;
+use libc::mprotect;
+use libc::{PROT_READ, PROT_WRITE};
+use memmap2::{MmapMut, MmapOptions};
+use std::os::raw::c_void;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::sync::atomic::fence;
+use std::sync::Arc;
+
+pub struct MmapBuf {
+    pub mm: MmapMut,
+    shape: Vec<usize>,
+}
+
+impl MmapBuf {
+    pub fn new(shape: Vec<usize>) -> Result<Self> {
+        let len: usize = shape.iter().product();
+        let layout = len * std::mem::size_of::<f64>();
+        let mm = MmapOptions::new().len(layout).map_anon()?;
+        Ok(Self { mm, shape })
+    }
+
+    pub fn ptr(&self) -> *mut c_void {
+        self.mm.as_ptr() as *mut _
+    }
+
+    pub fn byte_len(&self) -> usize {
+        self.mm.len()
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+}
+
+#[derive(Clone)]
+pub struct Shared {
+    pub mm: Arc<MmapBuf>,
+    pub seq: Arc<AtomicUsize>,
+}
+
+impl Shared {
+    pub fn new(mm: MmapBuf) -> Self {
+        Self { mm: Arc::new(mm), seq: Arc::new(AtomicUsize::new(0)) }
+    }
+
+    pub fn get(&self, idx: usize) -> f64 {
+        unsafe {
+            let base = self.mm.mm.as_ptr() as *const f64;
+            *base.add(idx)
+        }
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        self.mm.shape()
+    }
+
+    pub fn protect(&self, prot: i32) -> Result<()> {
+        let len = self.mm.byte_len();
+        let ret = unsafe { mprotect(self.mm.mm.as_ptr() as *mut _, len, prot) };
+        if ret != 0 {
+            Err(anyhow::anyhow!("mprotect failed"))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub fn start_write(&self) -> Result<()> {
+        self.seq.fetch_add(1, Ordering::AcqRel);
+        self.protect(PROT_READ | PROT_WRITE)
+    }
+
+    pub fn end_write(&self) -> Result<()> {
+        self.protect(PROT_READ)?;
+        self.seq.fetch_add(1, Ordering::Release);
+        Ok(())
+    }
+
+    pub fn read_snapshot(&self, buf: &mut [f64]) {
+        loop {
+            let start = self.seq.load(Ordering::Acquire);
+            if start % 2 == 1 { continue; }
+            fence(Ordering::Acquire);
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    self.mm.mm.as_ptr() as *const f64,
+                    buf.as_mut_ptr(),
+                    buf.len(),
+                );
+            }
+            fence(Ordering::Acquire);
+            if self.seq.load(Ordering::Relaxed) == start { break; }
+        }
+    }
+}
+

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,195 @@
+use anyhow::Result;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+
+use crate::memory::Shared;
+
+
+#[derive(Debug, Clone)]
+pub struct Update {
+    pub shape: Vec<u32>,
+    pub start: u32,
+    pub vals: Vec<f64>,
+}
+
+impl Update {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let shape_len = self.shape.len() as u32;
+        let val_len = self.vals.len() as u32;
+        let mut buf = Vec::with_capacity(4 + self.shape.len() * 4 + 4 + 4 + self.vals.len() * 8);
+        buf.extend_from_slice(&shape_len.to_le_bytes());
+        for d in &self.shape {
+            buf.extend_from_slice(&d.to_le_bytes());
+        }
+        buf.extend_from_slice(&self.start.to_le_bytes());
+        buf.extend_from_slice(&val_len.to_le_bytes());
+        for v in &self.vals {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+        buf
+    }
+}
+
+async fn read_exact_checked(sock: &mut TcpStream, buf: &mut [u8]) -> Result<bool> {
+    match sock.read_exact(buf).await {
+        Ok(_) => Ok(true),
+        Err(ref e) if e.kind() == ErrorKind::UnexpectedEof => Ok(false),
+        Err(ref e) if e.kind() == ErrorKind::ConnectionReset => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}
+
+async fn read_update_header(sock: &mut TcpStream) -> Result<Option<(Vec<usize>, usize, usize)>> {
+    let mut len_buf = [0u8; 4];
+    if !read_exact_checked(sock, &mut len_buf).await? {
+        return Ok(None);
+    }
+    let shape_len = u32::from_le_bytes(len_buf) as usize;
+
+    let mut shape_bytes = vec![0u8; shape_len * 4];
+    if !read_exact_checked(sock, &mut shape_bytes).await? {
+        return Ok(None);
+    }
+    let mut shape = Vec::with_capacity(shape_len);
+    for i in 0..shape_len {
+        let mut d = [0u8; 4];
+        d.copy_from_slice(&shape_bytes[i * 4..(i + 1) * 4]);
+        shape.push(u32::from_le_bytes(d) as usize);
+    }
+
+    if !read_exact_checked(sock, &mut len_buf).await? {
+        return Ok(None);
+    }
+    let start_idx = u32::from_le_bytes(len_buf) as usize;
+
+    if !read_exact_checked(sock, &mut len_buf).await? {
+        return Ok(None);
+    }
+    let val_len = u32::from_le_bytes(len_buf) as usize;
+
+    Ok(Some((shape, start_idx, val_len)))
+}
+
+async fn read_values(sock: &mut TcpStream, len: usize) -> Result<Option<Vec<f64>>> {
+    let mut buf = vec![0u8; len * 8];
+    if !read_exact_checked(sock, &mut buf).await? {
+        return Ok(None);
+    }
+    let mut vals = Vec::with_capacity(len);
+    for i in 0..len {
+        let mut b = [0u8; 8];
+        b.copy_from_slice(&buf[i * 8..(i + 1) * 8]);
+        vals.push(f64::from_le_bytes(b));
+    }
+    Ok(Some(vals))
+}
+
+async fn discard_values(sock: &mut TcpStream, len: usize) -> Result<bool> {
+    let mut buf = vec![0u8; len * 8];
+    read_exact_checked(sock, &mut buf).await
+}
+
+fn apply_update(state: &Shared, start_idx: usize, vals: &[f64], len: usize) -> Result<()> {
+    state.start_write()?;
+    let base = state.mm.mm.as_ptr() as *mut f64;
+    for (i, v) in (start_idx..start_idx + vals.len()).zip(vals.iter()) {
+        if i < len {
+            unsafe { *base.add(i) = *v; }
+        }
+    }
+    state.end_write()
+}
+
+pub async fn handle_peer(mut sock: TcpStream, state: Shared) -> Result<()> {
+    let addr = sock.peer_addr().ok();
+    println!("peer {:?} connected", addr);
+    let local_shape = state.shape().to_vec();
+    let len: usize = local_shape.iter().product();
+
+    loop {
+        let (shape, start_idx, val_len) = match read_update_header(&mut sock).await? {
+            Some(v) => v,
+            None => break,
+        };
+
+        if shape != local_shape {
+            println!("shape mismatch: recv {:?} local {:?}", shape, state.shape());
+            if !discard_values(&mut sock, val_len).await? { break; }
+            continue;
+        }
+
+        let vals = match read_values(&mut sock, val_len).await? {
+            Some(v) => v,
+            None => break,
+        };
+
+        apply_update(&state, start_idx, &vals, len)?;
+    }
+    println!("peer {:?} disconnected", addr);
+    Ok(())
+}
+
+pub async fn broadcaster(peers: Vec<SocketAddr>, rx: async_channel::Receiver<Update>) -> Result<()> {
+    let mut conns: Vec<(SocketAddr, TcpStream)> = Vec::new();
+    for p in &peers {
+        println!("connecting to peer {}", p);
+        match TcpStream::connect(*p).await {
+            Ok(s) => {
+                println!("connected to {}", p);
+                conns.push((*p, s));
+            }
+            Err(e) => println!("failed to connect to {}: {}", p, e),
+        }
+    }
+    while let Some(u) = rx.recv().await.ok() {
+        println!(
+            "broadcasting update shape {:?} start {} len {}",
+            u.shape,
+            u.start,
+            u.vals.len()
+        );
+        let data = u.to_bytes();
+
+        for p in &peers {
+            if !conns.iter().any(|(addr, _)| addr == p) {
+                println!("reconnecting to {}", p);
+                match TcpStream::connect(*p).await {
+                    Ok(s) => {
+                        println!("connected to {}", p);
+                        conns.push((*p, s));
+                    }
+                    Err(e) => println!("connect failed to {}: {}", p, e),
+                }
+            }
+        }
+
+        let mut alive = Vec::new();
+        for (addr, mut s) in conns {
+            match s.write_all(&data).await {
+                Ok(_) => {
+                    println!("sent to {}", addr);
+                    alive.push((addr, s));
+                }
+                Err(e) => {
+                    println!("send failed to {}: {}", addr, e);
+                }
+            }
+        }
+        conns = alive;
+    }
+    Ok(())
+}
+
+pub async fn listener(addr: SocketAddr, state: Shared) -> Result<()> {
+    println!("listening on {}", addr);
+    let lst = TcpListener::bind(addr).await?;
+    loop {
+        let (sock, peer) = lst.accept().await?;
+        println!("accepted connection from {}", peer);
+        let st = state.clone();
+        tokio::spawn(async move { let _ = handle_peer(sock, st).await; });
+    }
+}
+


### PR DESCRIPTION
## Summary
- restructure networking logic so handle_peer is composed from smaller helpers
- drop direct use of memory protections inside net module
- keep compile-time and runtime steps green

## Testing
- `cargo check`
- `maturin develop --release` *(fails: couldn't find virtualenv)*

------
https://chatgpt.com/codex/tasks/task_e_68434293c8e483328512bdc840f21dc7