### PR TITLE
Add DuckDB client example

### DIFF
--- a/examples/duckdb_client.py
+++ b/examples/duckdb_client.py
@@ -1,0 +1,23 @@
+import argparse
+import time
+import numpy as np
+import duckdb
+import raftmem
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--peers', default='0.0.0.0:7010')
+args = parser.parse_args()
+
+node = raftmem.start("duck", server=args.peers, shape=[10])
+con = duckdb.connect()
+
+while True:
+    with node.read() as arr:
+        # make a copy so duckdb owns the buffer
+        np_arr = np.array(arr)
+        con.register('raft', np_arr)
+        result = con.execute('SELECT AVG(column0) FROM raft').fetchall()[0][0]
+        print("\033[H\033[J", end="")
+        print('average', result)
+    time.sleep(1)
+


### PR DESCRIPTION
## Summary
- add a DuckDB example that queries raftmem data via SQL

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68439bc99bbc8332ad57016c82d422e9