### PR TITLE
Add on_update callback for Python clients

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -9,6 +9,13 @@ args = parser.parse_args()
 
 node = raftmem.start("b", server=args.peers, shape=[10,10])
 
+
+def handle_update(meta):
+    print("metadata", meta)
+
+
+node.on_update(handle_update)
+
 while True:
     with node.read() as arr:
         print("\033[H\033[J", end="")  # Move cursor to home position and clear screen

--- a/examples/server.py
+++ b/examples/server.py
@@ -13,9 +13,12 @@ node = raftmem.start("a", listen=args.listen, shape=[10,10])
 
 while True:
     with node.write() as a:
+        last = 0
         for _ in range(3):
             idx = random.randrange(len(a))
             a[idx] = random.random()
+            last = idx
+        node.send_meta({"last_index": last})
     with node.read() as arr:
         print("\033[H\033[J", end="")  # Move cursor to home position and clear screen
         print(arr)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -9,10 +9,19 @@ def test_snapshot_on_connect():
         arr[1] = 2.5
     time.sleep(1)
 
+    meta = {}
+
+    def cb(d):
+        meta.update(d)
+
     node_b = raftmem.start("b", server="127.0.0.1:7200", shape=[2])
+    node_b.on_update(cb)
+    node_a.send_meta({"last_index": 1})
+    node_a.flush(0)
     # allow time for snapshot to transfer
     time.sleep(2)
     with node_b.read() as arr:
         assert arr[0] == 1.5
         assert arr[1] == 2.5
+    assert meta.get("last_index") == 1
 


### PR DESCRIPTION
## Summary
- support metadata packets via UpdatePacket in networking layer
- implement Node.send_meta and Node.on_update
- notify clients of metadata in examples and tests

## Testing
- `maturin develop --release`
- `python -m pytest -q tests/test_snapshot.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_68439a1b8a08833289c4d31cb7139ad2