### PR TITLE
Add ticker timeseries example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ python examples/client.py --peers 0.0.0.0:7010
 `duckdb_client.py` demonstrates integrating with DuckDB and is executed in the
 same way.
 
+`ticker_server.py` and `ticker_client.py` stream random price updates for a
+set of stock tickers. The client displays the rolling mean for each ticker.
+
+Run the ticker server:
+```bash
+python examples/ticker_server.py --listen 0.0.0.0:7011
+```
+
+Connect with the ticker client:
+```bash
+python examples/ticker_client.py --peers 0.0.0.0:7011
+```
+
 ## Running the tests
 
 Ensure your virtual environment is active and the module is built as described

--- a/examples/ticker_client.py
+++ b/examples/ticker_client.py
@@ -1,0 +1,33 @@
+import argparse
+import time
+import numpy as np
+import raftmem
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--peers', default='0.0.0.0:7011')
+parser.add_argument('--tickers', default='AAPL,GOOG,MSFT')
+parser.add_argument('--window', type=int, default=5)
+args = parser.parse_args()
+
+tickers = args.tickers.split(',')
+window = args.window
+node = raftmem.start("ticker_client", server=args.peers, shape=[len(tickers), window])
+
+
+def handle_update(meta):
+    print('metadata', meta)
+
+
+node.on_update(handle_update)
+
+while True:
+    with node.read() as arr:
+        data = np.array(arr).reshape(len(tickers), window)
+        means = data.mean(axis=1)
+        print("\033[H\033[J", end="")
+        for t, m in zip(tickers, means):
+            print(f'{t}: {m:.2f}')
+        sys.stdout.flush()
+    time.sleep(1)
+


### PR DESCRIPTION
## Summary
- add `ticker_server.py` and `ticker_client.py` examples
- document new example in README

## Testing
- `maturin develop --release`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68443e7baeb88332b6227aa7d634c465