### PR TITLE
Fix slice subscription logic

### DIFF
--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -25,3 +25,26 @@ def test_snapshot_on_connect():
         assert arr[1] == 2.5
     assert meta.get("last_index") == 1
 
+
+
+def test_slice_snapshot():
+    node_a = raftmem.start("sa", listen="127.0.0.1:7201", shape=[4])
+    with node_a.write() as arr:
+        arr[0] = 1.0
+        arr[1] = 2.0
+        arr[2] = 3.0
+        arr[3] = 4.0
+    time.sleep(1)
+
+    maps = [([1], [2], [0], None)]
+    node_b = raftmem.start("sb", server="127.0.0.1:7201", shape=[2], maps=maps)
+    time.sleep(2)
+    with node_b.read() as arr:
+        assert list(arr) == [2.0, 3.0]
+
+    with node_a.write() as arr:
+        arr[1] = 5.0
+        arr[2] = 6.0
+    time.sleep(2)
+    with node_b.read() as arr:
+        assert list(arr) == [5.0, 6.0]


### PR DESCRIPTION
## Summary
- send snapshots after reading subscription so filtering works
- copy correct slice values when generating update packets
- add regression test for slice snapshots

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b2d42fc48332b990b79fc3a53b50