### PR TITLE
Add detailed README files for example programs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This project exposes a small Raft-backed shared memory buffer as a Python extens
 
 ## Running the examples
 
-The repository contains a simple server and two client examples located under
-`examples/`.
+The repository contains a number of example programs under `examples/`. The
+basic example is a simple server and client pair.
 
 Start a server in one terminal:
 ```bash
@@ -30,23 +30,21 @@ python examples/server.py --listen 0.0.0.0:7010
 
 In another terminal, connect with a client:
 ```bash
-python examples/client.py --peers 0.0.0.0:7010
+python examples/client.py --server 0.0.0.0:7010
 ```
 
-`duckdb_client.py` demonstrates integrating with DuckDB and is executed in the
-same way.
-
-`ticker_server.py` and `ticker_client.py` stream random price updates for a
-set of stock tickers. The client displays the rolling mean for each ticker.
+Additional example categories live under `examples/slices` and
+`examples/tickers`. The ticker examples stream random price updates for a set of
+stock tickers and the clients compute rolling statistics.
 
 Run the ticker server:
 ```bash
-python examples/ticker_server.py --listen 0.0.0.0:7011
+python examples/tickers/ticker_server.py --listen 0.0.0.0:7011
 ```
 
 Connect with the ticker client:
 ```bash
-python examples/ticker_client.py --peers 0.0.0.0:7011
+python examples/tickers/ticker_client.py --server 0.0.0.0:7011
 ```
 
 ## Running the tests

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Example Programs
+
+This directory contains small programs demonstrating how to use **memblast**. Make sure the package is built with:
+
+```bash
+maturin develop --release
+```
+
+All commands below should be run from the repository root.
+
+## Basic shared buffer
+
+- `server.py` – Starts a server hosting a 10×10 array and updates a few random values every second.
+- `client.py` – Connects to the server and prints the array along with any metadata updates.
+
+Run them in separate terminals:
+
+```bash
+python examples/server.py --listen 0.0.0.0:7010
+python examples/client.py --server 0.0.0.0:7010
+```
+
+## Slice examples
+
+Code under [slices/](slices/) shows how clients can map slices of a large array. See `slices/README.md` for details.
+
+## Ticker examples
+
+The [tickers/](tickers/) folder streams fake stock ticker data. See `tickers/README.md` for the full description.
+

--- a/examples/slices/README.md
+++ b/examples/slices/README.md
@@ -1,0 +1,48 @@
+# Slice Examples
+
+These programs demonstrate mapping portions of a large shared array to clients.
+A server maintains a `(tickers x window)` buffer of random data. Each client
+selects slices of that buffer in different ways.
+
+## Files
+
+- `slice_server.py` – Hosts the full array. The number of tickers and the size of the history window can be configured.
+- `slice_client.py` – Maps specific ticker rows into its own array using the mapping API and prints them.
+- `slice_all_client.py` – Connects to the server and views the entire dataset without slicing.
+- `slice_named_client.py` – Attaches named slices so they can be retrieved later with `node.ndarray(name)`.
+- `slice_duckdb_client.py` – Registers the mapped array with DuckDB and performs SQL queries over the live data.
+
+## Usage
+
+Start the server (default port 7020):
+
+```bash
+python examples/slices/slice_server.py --listen 0.0.0.0:7020
+```
+
+Run a basic slice client:
+
+```bash
+python examples/slices/slice_client.py --server 0.0.0.0:7020 --tickers 2,50,75
+```
+
+To view the full table:
+
+```bash
+python examples/slices/slice_all_client.py --server 0.0.0.0:7020
+```
+
+Named slice client:
+
+```bash
+python examples/slices/slice_named_client.py --server 0.0.0.0:7020 --tickers 2,50,75
+```
+
+DuckDB slice client:
+
+```bash
+python examples/slices/slice_duckdb_client.py --server 0.0.0.0:7020 --tickers 2,50,75
+```
+
+Use `--tickers` and `--window` on the server and clients to change the data shape.
+

--- a/examples/tickers/README.md
+++ b/examples/tickers/README.md
@@ -1,0 +1,32 @@
+# Ticker Examples
+
+These scripts simulate streaming stock price data. Start the server and then run one of the clients.
+
+## Files
+
+- `ticker_server.py` – Publishes random prices for a list of tickers. The `--tickers` option controls which symbols are generated and `--window` sets the history length.
+- `ticker_client.py` – Connects to the server, reads the shared buffer and prints the rolling mean price for each ticker.
+- `ticker_duckdb_client.py` – Similar to `ticker_client.py` but registers the shared array with DuckDB and uses SQL to compute averages.
+
+## Usage
+
+Start the server (default port 7011):
+
+```bash
+python examples/tickers/ticker_server.py --listen 0.0.0.0:7011
+```
+
+Connect with the basic client:
+
+```bash
+python examples/tickers/ticker_client.py --server 0.0.0.0:7011
+```
+
+Or run the DuckDB client:
+
+```bash
+python examples/tickers/ticker_duckdb_client.py --server 0.0.0.0:7011
+```
+
+Use `--tickers` and `--window` on any of the above commands to customise the data.
+


### PR DESCRIPTION
## Summary
- expand main README example section
- add an `examples/README.md`
- document slice examples in `examples/slices/README.md`
- document ticker examples in `examples/tickers/README.md`

## Testing
- `pip install -r requirements.txt`
- `maturin develop --release` *(fails: couldn't find virtualenv)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'memblast')*

------
https://chatgpt.com/codex/tasks/task_e_6844ca6579a08332aaa8b049f59fe96a