### PR TITLE
Implement versioned updates with logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +162,8 @@ dependencies = [
  "once_cell",
  "pyo3",
  "pyo3-build-config",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -417,10 +425,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ once_cell   = "1"
 async-channel = "1"   # used in lib.rs for the broadcast queue
 memmap2     = "0.9"
 libc        = "0.2"
+serde       = { version = "1", features = ["derive"] }
+serde_json  = "1"
 
 [build-dependencies]
 pyo3-build-config = "0.20"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod memory;
 mod net;
 
 use memory::{MmapBuf, Shared};
-use net::{client, serve, Update, UpdatePacket, Subscription, Mapping};
+use crate::net::{client, serve, Update, UpdatePacket, Subscription, Mapping};
 
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
@@ -17,6 +17,9 @@ use std::net::SocketAddr;
 use std::os::raw::{c_int, c_void};
 use libc::{PROT_READ};
 use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader};
+use serde_json;
 
 static RUNTIME: Lazy<Runtime> = Lazy::new(|| Runtime::new().expect("tokio"));
 
@@ -31,6 +34,7 @@ struct Node {
     pending_meta: Arc<Mutex<Option<String>>>,
     callback: RefCell<Option<Py<PyAny>>>,
     named: Arc<HashMap<String, Shared>>,
+    log: Option<Arc<Mutex<File>>>,
 }
 
 #[pymethods]
@@ -99,7 +103,9 @@ impl Node {
                 Update { start: s as u32, len: len as u32 }
             })
             .collect();
-        let packet = UpdatePacket { updates, meta };
+        let mut version = self.state.seq.load(std::sync::atomic::Ordering::Acquire);
+        if version % 2 == 1 { version += 1; }
+        let packet = UpdatePacket { updates, meta, version };
         let _ = self.tx.try_send(packet);
     }
 
@@ -142,6 +148,35 @@ impl Node {
         slf.state.read_snapshot(&mut scratch);
         let data = std::mem::take(&mut *scratch);
         Ok(ReadGuard { node: node_ref, arr: Some(data) })
+    }
+
+    fn sync_from_log(&self, path: &str, from_version: usize) -> PyResult<()> {
+        let file = File::open(path).map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let reader = BufReader::new(file);
+        let len: usize = self.shape.iter().product();
+        for line in reader.lines() {
+            let line = line.map_err(|e| PyValueError::new_err(e.to_string()))?;
+            let rec: net::LogRecord = serde_json::from_str(&line)
+                .map_err(|e| PyValueError::new_err(e.to_string()))?;
+            if rec.version < from_version { continue; }
+            for upd in rec.updates {
+                let start = upd.start as usize;
+                let vals = upd.values;
+                self.state.start_write().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+                let base = self.state.mm.mm.as_ptr() as *mut f64;
+                for (i, v) in (start..start + vals.len()).zip(vals.iter()) {
+                    if i < len {
+                        unsafe { *base.add(i) = *v; }
+                    }
+                }
+                self.state.end_write().map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            }
+            if let Some(m) = rec.meta {
+                let mut q = self.meta_queue.lock().unwrap();
+                q.push(m);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -233,7 +268,7 @@ impl ReadGuard {
 }
 
 #[pyfunction]
-#[pyo3(signature = (name, listen=None, server=None, shape=None, maps=None))]
+#[pyo3(signature = (name, listen=None, server=None, shape=None, maps=None, log_path=None))]
 fn start(
     _py: Python<'_>,
     name: &str,
@@ -241,6 +276,7 @@ fn start(
     server: Option<&str>,
     shape: Option<Vec<usize>>,
     maps: Option<Vec<(Vec<usize>, Vec<usize>, Option<Vec<usize>>, Option<String>)>>,
+    log_path: Option<&str>,
 ) -> PyResult<Node> {
     let shape = shape.unwrap_or_else(|| vec![10]);
     let len: usize = shape.iter().product();
@@ -270,6 +306,11 @@ fn start(
         Some(out)
     } else { None };
     let named_arc = Arc::new(named_map);
+    let log_handle = if let Some(path) = log_path {
+        let file = OpenOptions::new().create(true).append(true).open(path)
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        Some(Arc::new(Mutex::new(file)))
+    } else { None };
 
     if let Some(addr) = listen {
         let listen_addr: SocketAddr = addr.parse()
@@ -277,7 +318,8 @@ fn start(
         let st_clone = state.clone();
         let rx_clone = rx.clone();
         let pm = pending_meta.clone();
-        RUNTIME.spawn(serve(listen_addr, rx_clone, st_clone, pm));
+        let log_clone = log_handle.clone();
+        RUNTIME.spawn(serve(listen_addr, rx_clone, st_clone, pm, log_clone));
     }
 
     if let Some(addr) = server {
@@ -310,6 +352,7 @@ fn start(
         pending_meta,
         callback: RefCell::new(None),
         named: named_arc,
+        log: log_handle,
     })
 }
 


### PR DESCRIPTION
## Summary
- add `serde` and `serde_json`
- track a version on each `UpdatePacket`
- support serializing update logs and replaying them
- allow `start()` to accept an optional `log_path`

## Testing
- `maturin develop --release`
- `python -m pytest -q tests/test_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_6845170784fc83328d34d2f2661e25d2