### PR TITLE
Implement sliding window in slice server

### DIFF
--- a/examples/slices/README.md
+++ b/examples/slices/README.md
@@ -1,8 +1,9 @@
 # Slice Examples
 
 These programs demonstrate mapping portions of a large shared array to clients.
-A server maintains a `(tickers x window)` buffer of random data. Each client
-selects slices of that buffer in different ways.
+A server maintains a `(tickers x window)` sliding window of random data.
+Each new value is appended to the end of the window while older values move up.
+Clients map slices of that buffer in different ways.
 
 ## Files
 

--- a/examples/slices/slice_server.py
+++ b/examples/slices/slice_server.py
@@ -17,7 +17,9 @@ while True:
     with node.write() as arr:
         arr = arr.reshape(args.tickers, args.window)
         for i in range(args.tickers):
-            arr[i, index % args.window] = random.uniform(100.0, 200.0)
+            # Slide existing values to the left and append a new one at the end
+            arr[i, :-1] = arr[i, 1:]
+            arr[i, -1] = random.uniform(100.0, 200.0)
         node.send_meta({'index': index})
     index += 1
     with node.read() as data:


### PR DESCRIPTION
## Summary
- update slice_server.py to maintain a sliding window
- clarify server description in slice README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68451eba90648332b38fb80909cb7dc7