### PR TITLE
Update ticker examples with one-day history buffer

### DIFF
--- a/examples/tickers/README.md
+++ b/examples/tickers/README.md
@@ -4,7 +4,7 @@ These scripts simulate streaming stock price data. Start the server and then run
 
 ## Files
 
-- `ticker_server.py` – Publishes random prices for a list of tickers. The `--tickers` option controls which symbols are generated and `--window` sets the history length.
+- `ticker_server.py` – Publishes random prices for a list of tickers. The `--tickers` option controls which symbols are generated and `--window` sets the history length (defaults to one trading day).
 - `ticker_client.py` – Connects to the server, reads the shared buffer and prints the rolling mean price for each ticker.
 - `ticker_duckdb_client.py` – Similar to `ticker_client.py` but registers the shared array with DuckDB and uses SQL to compute averages.
 
@@ -29,4 +29,8 @@ python examples/tickers/ticker_duckdb_client.py --server 0.0.0.0:7011
 ```
 
 Use `--tickers` and `--window` on any of the above commands to customise the data.
+
+Each update includes metadata indicating the current index. The clients
+use this value to determine how many rows of the history buffer contain
+valid prices and compute statistics only over that slice.
 

--- a/examples/tickers/ticker_duckdb_client.py
+++ b/examples/tickers/ticker_duckdb_client.py
@@ -9,30 +9,35 @@ import duckdb
 parser = argparse.ArgumentParser()
 parser.add_argument('--server', default='0.0.0.0:7011')
 parser.add_argument('--tickers', default='AAPL,GOOG,MSFT')
-parser.add_argument('--window', type=int, default=5)
+parser.add_argument('--window', type=int, default=390,
+                    help='Size of the history buffer (minutes in a trading day)')
 args = parser.parse_args()
 
 tickers = args.tickers.split(',')
 window = args.window
 node = memblast.start("ticker_client", server=args.server, shape=[len(tickers), window])
 
+latest_idx = -1
+
 
 def handle_update(meta):
-    print('metadata', meta)
+    global latest_idx
+    latest_idx = meta.get('index', latest_idx)
 
 node.on_update(handle_update)
 
 con = duckdb.connect()
 # Register the numpy array ONCE. This is a live view into the shared memory,
 # so DuckDB will always see the latest data without re-registering.
-arr = node.ndarray()
-arr = arr.reshape([3,window])
+arr = node.ndarray().reshape(window, len(tickers))
 con.register('data', arr)
+query_template = 'SELECT ' + ', '.join(f'AVG(column{i})' for i in range(len(tickers))) + ' FROM (SELECT * FROM data LIMIT {limit})'
 
 while True:
     with node.read() as arr:
         data = np.array(arr).reshape(len(tickers), window)
-        means = con.execute('SELECT AVG(column0), AVG(column1), AVG(column2) FROM data').fetchall()[0]
+        valid = min(latest_idx + 1, window)
+        means = con.execute(query_template.format(limit=valid)).fetchall()[0] if valid > 0 else [0.0]*len(tickers)
         print("\033[H\033[J", end="")
         for t, m in zip(tickers, means):
             print(f'{t}: {m:.2f}')

--- a/examples/tickers/ticker_server.py
+++ b/examples/tickers/ticker_server.py
@@ -7,7 +7,8 @@ import sys
 parser = argparse.ArgumentParser()
 parser.add_argument('--listen', default='0.0.0.0:7011')
 parser.add_argument('--tickers', default='AAPL,GOOG,MSFT')
-parser.add_argument('--window', type=int, default=5)
+parser.add_argument('--window', type=int, default=390,
+                    help='Size of the history buffer (minutes in a trading day)')
 args = parser.parse_args()
 
 tickers = args.tickers.split(',')
@@ -18,8 +19,9 @@ index = 0
 while True:
     with node.write() as arr:
         arr = arr.reshape(len(tickers), window)
-        for i in range(len(tickers)):
-            arr[i, index % window] = random.uniform(100.0, 200.0)
+        if index < window:
+            for i in range(len(tickers)):
+                arr[i, index] = random.uniform(100.0, 200.0)
         node.send_meta({'index': index})
     with node.read() as data:
         data = data.reshape(len(tickers), window)


### PR DESCRIPTION
## Summary
- extend ticker example window to hold a full trading day
- track index metadata from server and use it to size client views
- document the new behaviour

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846252c703083328ae4d2f3dee5f3fc