### PR TITLE
Add update version numbers

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -10,3 +10,16 @@ def test_version_increments():
     with node.write() as arr:
         arr[0] = 2.0
     assert node.version == 2
+
+
+def test_network_version_updates():
+    node_a = memblast.start("va", listen="127.0.0.1:7300", shape=[1])
+    node_b = memblast.start("vb", server="127.0.0.1:7300", shape=[1])
+    import time
+    time.sleep(1)
+    assert node_b.version == 0
+    with node_a.write() as arr:
+        arr[0] = 3.14
+    time.sleep(1)
+    assert node_a.version == 1
+    assert node_b.version == 1


### PR DESCRIPTION
## Summary
- include a `version` field in each `UpdatePacket`
- increment and send the version on each flush
- encode/decode version in the network protocol

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848dce331e88332820af6d02a711d2b