### PR TITLE
Refactor update reading with callback

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -62,14 +62,14 @@ fn filtered_to_bytes(
         }
         buf.extend_from_slice(&u.start.to_le_bytes());
         buf.extend_from_slice(&(u.values.len() as u32).to_le_bytes());
-        for v in &u.values {
-            buf.extend_from_slice(&v.to_le_bytes());
-        }
         if let Some(name) = &u.name {
             buf.extend_from_slice(&(name.len() as u32).to_le_bytes());
             buf.extend_from_slice(name.as_bytes());
         } else {
             buf.extend_from_slice(&(0u32.to_le_bytes()));
+        }
+        for v in &u.values {
+            buf.extend_from_slice(&v.to_le_bytes());
         }
     }
     if let Some(meta) = meta {


### PR DESCRIPTION
## Summary
- remove intermediate `read_values` helper
- refactor `read_update_set` to stream values directly and call a closure for each update
- update `handle_peer` to use the new callback-based API
- build with `maturin develop --release`

## Testing
- `pip install -r requirements.txt`
- `maturin develop --release`


------
https://chatgpt.com/codex/tasks/task_e_684b969d56388332a7d56331de221cbc