### PR TITLE
Update README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 This project exposes a small Raft-backed shared memory buffer as a Python extension module.
 
+### Features
+
+- `version` property to track updates on each node
+- Subscribe to named sub regions and access them via `node.ndarray(name)`
+- Send and receive JSON metadata with synchronous or async callbacks
+
+### In progress
+
+- Switchable network layer (TCP or RDMA)
+- Metrics collection
+- Snapshots and MVCC
+
 ## Setup
 
 1. Create and activate a Python virtual environment:
@@ -32,6 +44,10 @@ In another terminal, connect with a client:
 ```bash
 python examples/client.py --server 0.0.0.0:7010
 ```
+Alternatively, a simple Quart-based WebSocket client is provided:
+```bash
+python examples/client_ws.py --server 0.0.0.0:7010
+```
 
 Additional example categories live under `examples/slices` and
 `examples/tickers`. The ticker examples stream random price updates for a set of
@@ -51,8 +67,9 @@ Connect with the ticker client:
 python examples/tickers/ticker_client.py --server 0.0.0.0:7011
 ```
 
-The `examples/life` directory runs a 256×256 Conway game of life. Start the server
-with `python examples/life/life_server.py` and connect using
+The `examples/life` directory runs a Conway game of life. The server defaults to
+a 64×64 world but the size is configurable with `--width`. Start the server with
+`python examples/life/life_server.py` and connect using
 `python examples/life/life_client.py`. Pass `--region` to the client to view a
 sub-region of the world.
 ## Running the tests

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ All commands below should be run from the repository root.
 
 - `server.py` – Starts a server hosting a 10×10 array and updates a few random values every second.
 - `client.py` – Connects to the server and prints the array along with any metadata updates.
+- `client_ws.py` – WebSocket client implemented with Quart.
 
 Run them in separate terminals:
 
@@ -30,8 +31,9 @@ The [tickers/](tickers/) folder streams fake stock ticker data. See `tickers/REA
 
 ## Game of Life example
 
-The [life/](life/) folder contains a 256×256 Conway game of life. Run the server and
-use the client to view the whole grid or a sub-region with the `--region` option.
+The [life/](life/) folder contains a Conway game of life. By default the server
+runs a 64×64 world. Use the client to view the whole grid or a sub-region with
+the `--region` option.
 
 ## Yahoo Finance example
 

--- a/examples/life/README.md
+++ b/examples/life/README.md
@@ -1,11 +1,13 @@
 # Conway's Game of Life
 
-This example runs a 256×256 Conway game of life simulation using **memblast**.
-The server maintains the world state and clients subscribe to updates.
+This example runs a Conway game of life simulation using **memblast**. The
+server maintains the world state and clients subscribe to updates. By default
+the world is 64×64 but the size can be adjusted.
 
 ## Files
 
-- `life_server.py` – Hosts the 256×256 world and updates it every half second.
+- `life_server.py` – Hosts the world and updates it every half second. Pass
+  `--width` to change the grid size (default 64).
 - `life_client.py` – Displays the world. Pass `--region row,col,h,w` to view
   only a portion of the grid.
 


### PR DESCRIPTION
## Summary
- show upcoming features in root README
- reference websocket example in README
- clarify game of life world size and update example README
- document version property and named sub-region subscriptions

## Testing
- `maturin develop --release`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_684c11da5bac8332b8ff462c977c7c8a