### PR TITLE
Add DuckDB snapshot MVCC example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ stock tickers and the clients compute rolling statistics.
 There is also a Yahoo Finance example under `examples/yfinance` that pulls
 real data using the `yfinance` library and demonstrates querying the live
 buffer with DuckDB. See `examples/yfinance/README.md` for details.
+An MVCC example under `examples/snapshots` shows how to compare the means of two snapshots with DuckDB.
 
 Run the ticker server:
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,3 +44,10 @@ registers the shared array with DuckDB. This mirrors the approach described in
 ## Neural network broadcast example
 
 The [nn_weights/](nn_weights/) folder trains a small neural network on the XOR problem with PyTorch and streams the weights as raw bytes so clients can map them directly for inference.
+
+## Snapshot MVCC example
+
+The [snapshots/](snapshots/) folder demonstrates multi-version
+concurrency control. The server records a snapshot after each update
+and the DuckDB client retrieves two versions to compare their means.
+

--- a/examples/snapshots/README.md
+++ b/examples/snapshots/README.md
@@ -1,0 +1,28 @@
+# Snapshot MVCC Example
+
+This folder demonstrates using snapshots with **memblast** and DuckDB.
+A small server updates an array every second and records a snapshot after
+each update. The DuckDB client fetches two versions of the data and
+compares their means using SQL.
+
+## Files
+
+- `snapshot_server.py` – Hosts a one-dimensional array and takes a snapshot
+  after every update.
+- `snapshot_duckdb_client.py` – Connects to the server, retrieves two
+  snapshots and computes their means with DuckDB.
+
+## Usage
+
+Start the server (default port 7013):
+
+```bash
+python examples/snapshots/snapshot_server.py --listen 0.0.0.0:7013
+```
+
+In another terminal fetch and compare two snapshots:
+
+```bash
+python examples/snapshots/snapshot_duckdb_client.py --server 0.0.0.0:7013 \
+    --snap1 3 --snap2 5
+```

--- a/examples/snapshots/snapshot_duckdb_client.py
+++ b/examples/snapshots/snapshot_duckdb_client.py
@@ -1,0 +1,37 @@
+import argparse
+import time
+import memblast
+import duckdb
+import numpy as np
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--server', default='0.0.0.0:7013')
+parser.add_argument('--snap1', type=int, default=1, help='First snapshot version')
+parser.add_argument('--snap2', type=int, default=2, help='Second snapshot version')
+args = parser.parse_args()
+
+node = memblast.start('snapshot_duck_client', server=args.server, shape=[5], snapshots=True)
+
+con = duckdb.connect()
+
+# Wait for the snapshots to exist on the server
+print('waiting for snapshots...')
+time.sleep(2)
+
+snap1 = node.version_data(args.snap1)
+snap2 = node.version_data(args.snap2)
+
+if snap1 is None or snap2 is None:
+    print('Snapshots not available.')
+    exit(1)
+
+arr1 = np.array(snap1)
+arr2 = np.array(snap2)
+con.register('s1', arr1)
+con.register('s2', arr2)
+
+m1 = con.execute('SELECT AVG(*) FROM s1').fetchall()[0][0]
+m2 = con.execute('SELECT AVG(*) FROM s2').fetchall()[0][0]
+
+print(f'Snapshot {args.snap1} mean: {m1:.4f}')
+print(f'Snapshot {args.snap2} mean: {m2:.4f}')

--- a/examples/snapshots/snapshot_server.py
+++ b/examples/snapshots/snapshot_server.py
@@ -1,0 +1,23 @@
+import argparse
+import time
+import numpy as np
+import memblast
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--listen', default='0.0.0.0:7013')
+parser.add_argument('--size', type=int, default=5)
+args = parser.parse_args()
+
+node = memblast.start('snapshot_server', listen=args.listen, shape=[args.size], snapshots=True)
+
+while True:
+    with node.write() as arr:
+        arr[:] = np.random.random(args.size)
+    node.take_snapshot()
+    with node.read() as arr:
+        print("\033[H\033[J", end="")
+        print(f'version: {node.version}')
+        print(arr)
+        sys.stdout.flush()
+    time.sleep(1)


### PR DESCRIPTION
## Summary
- add snapshot MVCC example with server and DuckDB client
- document example in README files

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca886ff4083328846e08b29cd51af