### PR TITLE
Add peer connection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ The `examples/life` directory runs a 256×256 Conway game of life. Start the ser
 with `python examples/life/life_server.py` and connect using
 `python examples/life/life_client.py`. Pass `--region` to the client to view a
 sub-region of the world.
+
+For a peer-to-peer setup where each process owns a portion of the array and
+receives updates for the rest, use `examples/peer_split.py`. Start one peer
+with `--name a` and the other with `--name b` to split a single buffer between
+them.  Each node starts a listener and then calls `connect()` to subscribe to
+its counterpart:
+
+```bash
+python examples/peer_split.py --name a
+python examples/peer_split.py --name b
+```
+
+Nodes can join other peers dynamically with `node.connect("addr", maps=...)`.
+This spawns an additional subscription client while continuing to publish
+updates from the local region.
+
 ## Running the tests
 
 Ensure your virtual environment is active and the module is built as described

--- a/examples/peer_split.py
+++ b/examples/peer_split.py
@@ -1,0 +1,48 @@
+import argparse
+import time
+import memblast
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--name', choices=['a', 'b'], required=True,
+                    help='peer identity (a or b)')
+parser.add_argument('--listen')
+parser.add_argument('--peer')
+parser.add_argument('--size', type=int, default=10)
+args = parser.parse_args()
+
+size = args.size
+half = size // 2
+
+if args.name == 'a':
+    listen = args.listen or '0.0.0.0:7100'
+    peer = args.peer or '0.0.0.0:7101'
+    local_start = 0
+    remote_start = half
+else:
+    listen = args.listen or '0.0.0.0:7101'
+    peer = args.peer or '0.0.0.0:7100'
+    local_start = half
+    remote_start = 0
+
+maps = [([remote_start], [half], [remote_start], None)]
+
+node = memblast.start(
+    f'peer_{args.name}',
+    listen=listen,
+    shape=[size],
+)
+node.connect(peer, maps=maps)
+
+index = 0
+while True:
+    with node.write() as arr:
+        arr[local_start + index % half] = float(index)
+        node.send_meta({'index': index})
+    with node.read() as arr:
+        print("\033[H\033[J", end="")
+        print(f'peer {args.name} version: {node.version}')
+        print(list(arr))
+        sys.stdout.flush()
+    index += 1
+    time.sleep(1)

--- a/src/net.rs
+++ b/src/net.rs
@@ -461,7 +461,7 @@ fn filter_updates(
 pub async fn handle_peer(
     mut sock: TcpStream,
     state: Shared,
-    named: Arc<HashMap<String, Shared>>,
+    named: Arc<Mutex<HashMap<String, Shared>>>,
     meta: Arc<Mutex<Vec<String>>>,
     version: Arc<AtomicU64>,
     hash_check: bool,
@@ -476,7 +476,7 @@ pub async fn handle_peer(
             if shape == local_shape && name.is_none() {
                 Some(state.clone())
             } else if let Some(nm) = name {
-                named_map.get(nm).cloned()
+                named_map.lock().unwrap().get(nm).cloned()
             } else {
                 println!("shape mismatch: recv {:?} local {:?}", shape, local_shape);
                 None
@@ -558,7 +558,7 @@ pub async fn serve(
 pub async fn client(
     server: SocketAddr,
     state: Shared,
-    named: Arc<HashMap<String, Shared>>,
+    named: Arc<Mutex<HashMap<String, Shared>>>,
     meta: Arc<Mutex<Vec<String>>>,
     version: Arc<AtomicU64>,
     sub: Subscription,


### PR DESCRIPTION
## Summary
- allow connecting to additional peers with `Node.connect`
- update peer split example to use the new method
- document dynamic `connect()` usage in README

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d05fc25bc8332a757907bb760ad7f