### PR TITLE
Add 4-peer distributed region example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ The `examples/life` directory runs a 256×256 Conway game of life. Start the ser
 with `python examples/life/life_server.py` and connect using
 `python examples/life/life_client.py`. Pass `--region` to the client to view a
 sub-region of the world.
+
+For a peer-to-peer setup where each process owns one quadrant of the shared
+array and subscribes to updates from the others, run `examples/peer_split.py`.
+Each peer listens on its own port (defaults are 7100&ndash;7103) and uses the
+`--peers` option to connect to the remaining addresses. Launch four peers (`a`
+through `d`) to divide the buffer into quadrants:
+
+```bash
+python examples/peer_split.py --name a
+python examples/peer_split.py --name b
+python examples/peer_split.py --name c
+python examples/peer_split.py --name d
+```
+
 ## Running the tests
 
 Ensure your virtual environment is active and the module is built as described

--- a/examples/peer_split.py
+++ b/examples/peer_split.py
@@ -1,0 +1,64 @@
+import argparse
+import time
+import memblast
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--name', choices=['a', 'b', 'c', 'd'], required=True,
+                    help='peer identity (a-d)')
+parser.add_argument('--listen')
+parser.add_argument('--peers', nargs='*')
+parser.add_argument('--size', type=int, default=8,
+                    help='dimension of the square array (even)')
+args = parser.parse_args()
+
+dim = args.size
+half = dim // 2
+
+orders = {'a': 0, 'b': 1, 'c': 2, 'd': 3}
+ports = {'a': 7100, 'b': 7101, 'c': 7102, 'd': 7103}
+
+ordinal = orders[args.name]
+
+listen = args.listen or f'0.0.0.0:{ports[args.name]}'
+default_peers = [f'0.0.0.0:{ports[n]}' for n in orders if n != args.name]
+servers = args.peers or default_peers
+
+coords = {
+    'a': [0, 0],
+    'b': [0, half],
+    'c': [half, 0],
+    'd': [half, half],
+}
+
+start = coords[args.name]
+# each mapping copies a quadrant from the peer into the same coordinates
+maps = [ (list(coord), [half, half], list(coord), None)
+         for peer, coord in coords.items() if peer != args.name ]
+
+node = memblast.start(
+    f'peer_{args.name}',
+    listen=listen,
+    servers=servers,
+    shape=[dim, dim],
+    maps=maps,
+)
+
+index = 0
+while True:
+    with node.write() as arr:
+        val = float((index % 100) + ordinal * 100)
+        for r in range(half):
+            for c in range(half):
+                idx = (start[0] + r) * dim + start[1] + c
+                arr[idx] = val
+        node.send_meta({'index': index})
+    with node.read() as arr:
+        print("\033[H\033[J", end="")
+        print(f'peer {args.name} version: {node.version}')
+        for r in range(dim):
+            row_vals = arr[r * dim:(r + 1) * dim]
+            print(' '.join(f'{v:5.1f}' for v in row_vals))
+        sys.stdout.flush()
+    index += 1
+    time.sleep(1)


### PR DESCRIPTION
## Summary
- update `examples/peer_split.py` to support four peers
- document four-peer usage in README
- clarify usage of `--peers`

## Testing
- `pip install -r requirements.txt`
- `python -m venv .venv && source .venv/bin/activate`
- `maturin develop --release`
- `pip install pytest`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_684d05fc25bc8332a757907bb760ad7f