### PR TITLE
Add benchmark example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,3 +47,13 @@ The [nn_weights/](nn_weights/) folder trains a small neural network on the XOR p
 
 The [heatmap/](heatmap/) folder streams a dynamic sine-wave heatmap. Clients render it as ASCII art.
 
+
+## Benchmark example
+
+The `benchmark.py` script measures how many updates per second can be applied
+for different square matrix sizes. Pass `--sizes` with a comma-separated list
+and `--duration` to control how long each run lasts.
+
+```bash
+python examples/benchmark.py --sizes 64,128,256 --duration 5
+```

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,0 +1,32 @@
+import argparse
+import time
+import numpy as np
+import memblast
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--sizes", default="64,128,256", help="Comma separated list of square matrix sizes"
+)
+parser.add_argument(
+    "--duration", type=float, default=5.0, help="Seconds to run each benchmark per size"
+)
+args = parser.parse_args()
+
+sizes = [int(s) for s in args.sizes.split(",") if s]
+
+
+def run_bench(size: int) -> float:
+    node = memblast.start(f"bench_{size}", shape=[size, size])
+    count = 0
+    start = time.time()
+    while time.time() - start < args.duration:
+        with node.write() as arr:
+            arr = arr.reshape(size, size)
+            arr.fill(float(count))
+        count += 1
+    return count / args.duration
+
+
+for sz in sizes:
+    rate = run_bench(sz)
+    print(f"{sz}x{sz}: {rate:.2f} updates/sec")


### PR DESCRIPTION
## Summary
- add `benchmark.py` to benchmark update rate for matrices
- document benchmark example in `examples/README.md`

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851877bc9b88332bbb53db7c8e92d8a