### PR TITLE
Rename send_meta to version_meta with checks

### DIFF
--- a/examples/heatmap/heatmap_server.py
+++ b/examples/heatmap/heatmap_server.py
@@ -22,7 +22,7 @@ while True:
     with node.write() as arr:
         arr = arr.reshape(size, size)
         arr[:] = data
-        node.send_meta({'phase': float(phase)})
+        node.version_meta({'phase': float(phase)})
     with node.read() as arr:
         arr = arr.reshape(size, size)
         print("\033[H\033[J", end="")

--- a/examples/peer_split.py
+++ b/examples/peer_split.py
@@ -51,7 +51,7 @@ while True:
         val = float((index + ordinal) % 4)
         view = arr.reshape(dim, dim)
         view[start[0]:start[0]+half, start[1]:start[1]+half] = val
-        node.send_meta({'index': index})
+        node.version_meta({'index': index})
     with node.read() as arr:
         print("\033[H\033[J", end="")
         print(f'peer {args.name} version: {node.version}')

--- a/examples/server.py
+++ b/examples/server.py
@@ -18,7 +18,7 @@ while True:
             idx = random.randrange(len(a))
             a[idx] = random.random()
             last = idx
-        node.send_meta({"last_index": last})
+        node.version_meta({"last_index": last})
     with node.read() as arr:
         print("\033[H\033[J", end="")
         print(f"version: {node.version}")

--- a/examples/slices/slice_server.py
+++ b/examples/slices/slice_server.py
@@ -18,7 +18,7 @@ while True:
         arr = arr.reshape(args.tickers, args.window)
         for i in range(args.tickers):
             arr[i, index % args.window] = random.uniform(100.0, 200.0)
-        node.send_meta({'index': index})
+        node.version_meta({'index': index})
     index += 1
     with node.read() as data:
         data = data.reshape(args.tickers, args.window)

--- a/examples/tickers/ticker_server.py
+++ b/examples/tickers/ticker_server.py
@@ -22,7 +22,7 @@ while True:
         if index < window:
             for i in range(len(tickers)):
                 arr[i, index] = random.uniform(100.0, 200.0)
-        node.send_meta({'index': index})
+        node.version_meta({'index': index})
     with node.read() as data:
         data = data.reshape(len(tickers), window)
         print("\033[H\033[J", end="")

--- a/examples/yfinance/yfinance_server.py
+++ b/examples/yfinance/yfinance_server.py
@@ -45,7 +45,7 @@ while True:
         arr = arr.reshape(len(tickers), window)
         for i, price in enumerate(prices):
             arr[i, index % window] = price
-        node.send_meta({'index': index})
+        node.version_meta({'index': index})
 
     with node.read() as arr:
         arr = np.array(arr).reshape(len(tickers), window)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,11 @@ impl Node {
         let _ = self.tx.try_send(packet);
     }
 
-    fn send_meta(&self, meta: &PyAny) -> PyResult<()> {
+    fn version_meta(&self, meta: &PyAny) -> PyResult<()> {
+        // ensure we are currently in a write block by checking the sequence
+        if self.state.seq.load(Ordering::Acquire) % 2 == 0 {
+            return Err(PyRuntimeError::new_err("meta updates require an active write block"));
+        }
         let py = meta.py();
         let json = PyModule::import(py, "json")?.call_method1("dumps", (meta,))?.extract::<String>()?;
         *self.pending_meta.lock().unwrap() = Some(json);

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -16,8 +16,8 @@ def test_snapshot_on_connect():
 
     node_b = memblast.start("b", server="127.0.0.1:7200", shape=[2])
     node_b.on_update(cb)
-    node_a.send_meta({"last_index": 1})
-    node_a.flush(0)
+    with node_a.write():
+        node_a.version_meta({"last_index": 1})
     # allow time for snapshot to transfer
     time.sleep(2)
     with node_b.read() as arr:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,3 +1,5 @@
+import time
+import pytest
 import memblast
 
 
@@ -15,7 +17,6 @@ def test_version_increments():
 def test_network_version_updates():
     node_a = memblast.start("va", listen="127.0.0.1:7300", shape=[1])
     node_b = memblast.start("vb", server="127.0.0.1:7300", shape=[1])
-    import time
     time.sleep(1)
     assert node_b.version == 0
     with node_a.write() as arr:
@@ -23,3 +24,9 @@ def test_network_version_updates():
     time.sleep(1)
     assert node_a.version == 1
     assert node_b.version == 1
+
+
+def test_version_meta_requires_write():
+    node = memblast.start("mx", shape=[1])
+    with pytest.raises(RuntimeError):
+        node.version_meta({"bad": True})


### PR DESCRIPTION
## Summary
- rename `send_meta` to `version_meta`
- require write block before updating metadata
- adjust tests and examples for new method

## Testing
- `maturin build --release`
- `pip install target/wheels/*.whl`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518e40ba348332b90d71ee7f03b793