### PR TITLE
Update examples for per-peer version tracking

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -7,9 +7,8 @@ async def handle_update(node, meta):
     print("metadata", meta)
     with node.read() as arr:
         print("\033[H\033[J", end="")
-        local = node.version.get(node.name, 0)
         remote = node.version.get(args.server, 0)
-        print(f"versions local={local} remote={remote}")
+        print(f"version: {remote}")
         print(arr)
         sys.stdout.flush()
 

--- a/examples/client.py
+++ b/examples/client.py
@@ -7,7 +7,9 @@ async def handle_update(node, meta):
     print("metadata", meta)
     with node.read() as arr:
         print("\033[H\033[J", end="")
-        print(f"version: {node.version}")
+        local = node.version.get(node.name, 0)
+        remote = node.version.get(args.server, 0)
+        print(f"versions local={local} remote={remote}")
         print(arr)
         sys.stdout.flush()
 

--- a/examples/peer_split.py
+++ b/examples/peer_split.py
@@ -54,7 +54,7 @@ while True:
         node.send_meta({'index': index})
     with node.read() as arr:
         print("\033[H\033[J", end="")
-        print(f'peer {args.name} version: {node.version}')
+        print(f'peer {args.name} versions: {node.version}')
         view = arr.reshape(dim, dim)
         for r in range(dim):
             row_vals = view[r]

--- a/examples/peer_split.py
+++ b/examples/peer_split.py
@@ -54,7 +54,8 @@ while True:
         node.send_meta({'index': index})
     with node.read() as arr:
         print("\033[H\033[J", end="")
-        print(f'peer {args.name} versions: {node.version}')
+        version_str = ' '.join(f'{k}={v}' for k, v in node.version.items())
+        print(f'peer {args.name} versions: {version_str}')
         view = arr.reshape(dim, dim)
         for r in range(dim):
             row_vals = view[r]

--- a/examples/server.py
+++ b/examples/server.py
@@ -21,7 +21,7 @@ while True:
         node.send_meta({"last_index": last})
     with node.read() as arr:
         print("\033[H\033[J", end="")
-        print(f"version: {node.version}")
+        print(f"version: {node.version.get(node.name, 0)}")
         print(arr)
         sys.stdout.flush()
     time.sleep(1)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -3,13 +3,13 @@ import memblast
 
 def test_version_increments():
     node = memblast.start("ver", shape=[1])
-    assert node.version == 0
+    assert node.version[node.name] == 0
     with node.write() as arr:
         arr[0] = 1.0
-    assert node.version == 1
+    assert node.version[node.name] == 1
     with node.write() as arr:
         arr[0] = 2.0
-    assert node.version == 2
+    assert node.version[node.name] == 2
 
 
 def test_network_version_updates():
@@ -17,9 +17,9 @@ def test_network_version_updates():
     node_b = memblast.start("vb", server="127.0.0.1:7300", shape=[1])
     import time
     time.sleep(1)
-    assert node_b.version == 0
+    assert node_b.version["127.0.0.1:7300"] == 0
     with node_a.write() as arr:
         arr[0] = 3.14
     time.sleep(1)
-    assert node_a.version == 1
-    assert node_b.version == 1
+    assert node_a.version[node_a.name] == 1
+    assert node_b.version["127.0.0.1:7300"] == 1


### PR DESCRIPTION
## Summary
- show per-peer version info in client example
- expose local version only in server example
- print versions dictionary in peer split example

## Testing
- `maturin develop --release`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851b0f4119c8332ac61af5d52263493