### PR TITLE
Fix version test port allocation

### DIFF
--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -14,16 +14,18 @@ def test_version_increments():
     assert node.version[node.name] == 2
 
 
-def test_network_version_updates():
-    node_a = memblast.start("va", listen="127.0.0.1:7300", shape=[1])
-    node_b = memblast.start("vb", server="127.0.0.1:7300", shape=[1])
+def test_network_version_updates(free_tcp_port):
+    port = free_tcp_port
+    addr = f"127.0.0.1:{port}"
+    node_a = memblast.start("va", listen=addr, shape=[1])
+    node_b = memblast.start("vb", server=addr, shape=[1])
     time.sleep(1)
-    assert node_b.version["127.0.0.1:7300"] == 0
+    assert node_b.version[addr] == 0
     with node_a.write() as arr:
         arr[0] = 3.14
     time.sleep(1)
     assert node_a.version[node_a.name] == 1
-    assert node_b.version["127.0.0.1:7300"] == 1
+    assert node_b.version[addr] == 1
 
 
 def test_version_meta_requires_write():


### PR DESCRIPTION
## Summary
- avoid fixed port numbers in `test_network_version_updates`
- use pytest `free_tcp_port` fixture

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851ce98c23883329950727095e3d01e