### PR TITLE
Switch to bincode serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,12 +207,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-channel",
+ "bincode",
  "libc",
  "memmap2",
  "numpy",
  "once_cell",
  "pyo3",
  "pyo3-build-config",
+ "serde",
  "sha2",
  "tokio",
 ]
@@ -470,6 +481,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ async-channel = "1"   # used in lib.rs for the broadcast queue
 memmap2     = "0.9"
 libc        = "0.2"
 sha2        = "0.10"
+serde       = { version = "1", features = ["derive"] }
+bincode     = "1"
 
 [build-dependencies]
 pyo3-build-config = "0.20"


### PR DESCRIPTION
## Summary
- replace custom byte protocol with serde/bincode
- clean up net module to use typed WireUpdate messages

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530a8c1e348332b6f0d2cd8bd62c8c