### PR TITLE
Add multi-arch wheel publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Build and publish wheels
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build wheels
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        target: [x86_64, aarch64]
+        exclude:
+          - os: windows-latest
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: ${{ matrix.target }}
+          args: --release --out dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}-${{ matrix.target }}
+          path: dist
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v4
+      - uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: publish
+          args: --skip-existing dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ target
 .venv
 .tmp
 .cargo
+
+dist
+wheelhouse
+
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ browser via WebSockets, and running a peer-to-peer mesh.
    maturin develop --release
    ```
 
+
+## Building wheels for PyPI
+
+A GitHub Actions workflow builds and uploads wheels for Linux, macOS and Windows on x86_64 and aarch64 architectures. Push a tag like `v0.1.0` with the `PYPI_API_TOKEN` secret set to publish.
+
 ## Running the examples
 
 The repository contains a number of example programs under `examples/`. The

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["maturin>=1.4"]
+build-backend = "maturin"
+
+[project]
+name = "memblast"
+version = "0.1.0"
+requires-python = ">=3.8"
+description = "Embedded, replicated shared NumPy array demo"
+authors = [{name="Your Name", email="you@example.com"}]
+readme = "README.md"
+license = {text = "MIT OR Apache-2.0"}
+
+[tool.maturin]
+bindings = "pyo3"


### PR DESCRIPTION
## Summary
- support building with maturin via pyproject
- add GitHub Actions workflow to publish wheels for x86_64 and aarch64
- document the workflow and ignore build output

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539e3c48508332a387be12d3e3bb4e