### PR TITLE
Improve connection callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +221,7 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "serde",
+ "serde_json",
  "sha2",
  "tokio",
 ]
@@ -477,6 +484,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +513,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ libc        = "0.2"
 sha2        = "0.10"
 serde       = { version = "1", features = ["derive"] }
 bincode     = "1"
+serde_json = "1"
 
 [build-dependencies]
 pyo3-build-config = "0.20"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use net::{client, serve, Update, UpdatePacket, Subscription, Mapping};
 
 use once_cell::sync::Lazy;
 use pyo3::prelude::*;
-use pyo3::types::{PyModule, PyDict};
+use pyo3::types::{PyModule, PyDict, PyString};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use numpy::{Element, PyArray1};
 use numpy::npyffi::{PY_ARRAY_API, NpyTypes, NPY_ARRAY_WRITEABLE, npy_intp};
@@ -31,6 +31,8 @@ struct Node {
     len: usize,
     scratch: RefCell<Vec<f64>>,
     meta_queue: Arc<Mutex<Vec<String>>>,
+    connect_queue: Arc<Mutex<Vec<String>>>,
+    disconnect_queue: Arc<Mutex<Vec<String>>>,
     pending_meta: Arc<Mutex<Option<String>>>,
     callback: RefCell<Option<Py<PyAny>>>,
     named: Arc<HashMap<String, Shared>>,
@@ -255,8 +257,58 @@ impl ReadGuard {
     }
 }
 
+fn spawn_callback_thread(
+    queue: Arc<Mutex<Vec<String>>>,
+    node: Py<Node>,
+    cb: PyObject,
+    loop_obj: PyObject,
+    parse_json: bool,
+) {
+    std::thread::spawn(move || {
+        use std::time::Duration;
+        loop {
+            let items = {
+                let mut q = queue.lock().unwrap();
+                if q.is_empty() { None } else { Some(q.drain(..).collect::<Vec<_>>()) }
+            };
+            if let Some(items) = items {
+                Python::with_gil(|py| {
+                    let loads = if parse_json {
+                        Some(py.import("json").unwrap().getattr("loads").unwrap())
+                    } else {
+                        None
+                    };
+                    for it in items {
+                        let arg = match &loads {
+                            Some(l) => l.call1((it,)).unwrap().into_py(py),
+                            None => PyString::new(py, &it).into_py(py),
+                        };
+                        let coro = cb.as_ref(py).call1((node.clone_ref(py), arg)).unwrap();
+                        py.import("asyncio").unwrap()
+                            .call_method1("run_coroutine_threadsafe", (coro, loop_obj.as_ref(py)))
+                            .unwrap();
+                    }
+                });
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    });
+}
+
 #[pyfunction]
-#[pyo3(signature = (name, listen=None, server=None, servers=None, shape=None, maps=None, on_update_async=None, event_loop=None, check_hash=false))]
+#[pyo3(signature = (
+    name,
+    listen=None,
+    server=None,
+    servers=None,
+    shape=None,
+    maps=None,
+    on_update_async=None,
+    on_connect=None,
+    on_disconnect=None,
+    event_loop=None,
+    check_hash=false
+))]
 fn start(
     py: Python<'_>,
     name: &str,
@@ -266,6 +318,8 @@ fn start(
     shape: Option<Vec<usize>>,
     maps: Option<Vec<(Vec<usize>, Vec<usize>, Option<Vec<usize>>, Option<String>)>>,
     on_update_async: Option<PyObject>,
+    on_connect: Option<PyObject>,
+    on_disconnect: Option<PyObject>,
     event_loop: Option<PyObject>,
     check_hash: bool,
 ) -> PyResult<Py<Node>> {
@@ -275,6 +329,8 @@ fn start(
     let state = Shared::new(buf);
     let (tx, rx) = async_channel::bounded::<UpdatePacket>(1024);
     let meta_queue = Arc::new(Mutex::new(Vec::new()));
+    let connect_queue = Arc::new(Mutex::new(Vec::new()));
+    let disconnect_queue = Arc::new(Mutex::new(Vec::new()));
     let pending_meta = Arc::new(Mutex::new(None));
     let local_version = Arc::new(AtomicU64::new(0));
     let versions = Arc::new(Mutex::new(HashMap::new()));
@@ -307,7 +363,9 @@ fn start(
         let st_clone = state.clone();
         let rx_clone = rx.clone();
         let pm = pending_meta.clone();
-        RUNTIME.spawn(serve(listen_addr, rx_clone, st_clone, pm));
+        let cq = connect_queue.clone();
+        let dq = disconnect_queue.clone();
+        RUNTIME.spawn(serve(listen_addr, rx_clone, st_clone, pm, cq, dq));
     }
 
     let mut peer_addrs: Vec<String> = servers.clone().unwrap_or_default();
@@ -332,7 +390,9 @@ fn start(
         };
         let named_clone = named_arc.clone();
         let ver_clone = versions.clone();
-        RUNTIME.spawn(client(server_addr, st_clone, named_clone, mq, ver_clone, sub.clone()));
+        let cq = connect_queue.clone();
+        let dq = disconnect_queue.clone();
+        RUNTIME.spawn(client(server_addr, st_clone, named_clone, mq, ver_clone, sub.clone(), cq, dq));
     }
 
     state.protect(PROT_READ).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
@@ -347,6 +407,8 @@ fn start(
         len,
         scratch: RefCell::new(vec![0.0; len]),
         meta_queue: meta_queue.clone(),
+        connect_queue: connect_queue.clone(),
+        disconnect_queue: disconnect_queue.clone(),
         pending_meta: pending_meta.clone(),
         callback: RefCell::new(None),
         named: named_arc.clone(),
@@ -354,60 +416,29 @@ fn start(
         versions: versions.clone(),
     })?;
 
-    if let Some(cb) = on_update_async {
-        if let Some(loop_obj) = event_loop {
-            let mq = meta_queue.clone();
-            let node_clone = node.clone();
-            std::thread::spawn(move || {
-                loop {
-                    let metas = {
-                        let mut q = mq.lock().unwrap();
-                        if q.is_empty() { None } else { Some(q.drain(..).collect::<Vec<_>>()) }
-                    };
-                    if let Some(items) = metas {
-                        Python::with_gil(|py| {
-                            let loads = py.import("json").unwrap().getattr("loads").unwrap();
-                            for m in items {
-                                let obj = loads.call1((m,)).unwrap();
-                                let coro = cb.as_ref(py).call1((node_clone.clone_ref(py), obj)).unwrap();
-                                py.import("asyncio").unwrap()
-                                    .call_method1("run_coroutine_threadsafe", (coro, loop_obj.as_ref(py)))
-                                    .unwrap();
-                            }
-                        });
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                }
-            });
+    let need_loop = on_update_async.is_some() || on_connect.is_some() || on_disconnect.is_some();
+    if need_loop {
+        let loop_obj: PyObject = if let Some(ref obj) = event_loop {
+            obj.clone_ref(py)
         } else {
             let asyncio = PyModule::import(py, "asyncio")?;
-            let new_loop: PyObject = asyncio.call_method0("new_event_loop")?.into();
-            asyncio.call_method1("set_event_loop", (new_loop.as_ref(py),))?;
-            let mq = meta_queue.clone();
-            let node_clone = node.clone();
-            let loop_clone = new_loop.clone_ref(py);
-            std::thread::spawn(move || {
-                loop {
-                    let metas = {
-                        let mut q = mq.lock().unwrap();
-                        if q.is_empty() { None } else { Some(q.drain(..).collect::<Vec<_>>()) }
-                    };
-                    if let Some(items) = metas {
-                        Python::with_gil(|py| {
-                            let loads = py.import("json").unwrap().getattr("loads").unwrap();
-                            for m in items {
-                                let obj = loads.call1((m,)).unwrap();
-                                let coro = cb.as_ref(py).call1((node_clone.clone_ref(py), obj)).unwrap();
-                                py.import("asyncio").unwrap()
-                                    .call_method1("run_coroutine_threadsafe", (coro, loop_clone.as_ref(py)))
-                                    .unwrap();
-                            }
-                        });
-                    }
-                    std::thread::sleep(std::time::Duration::from_millis(10));
-                }
-            });
-            new_loop.as_ref(py).call_method0("run_forever")?;
+            let obj: PyObject = asyncio.call_method0("new_event_loop")?.into();
+            asyncio.call_method1("set_event_loop", (obj.as_ref(py),))?;
+            obj
+        };
+
+        if let Some(cb) = on_update_async {
+            spawn_callback_thread(meta_queue.clone(), node.clone(), cb, loop_obj.clone_ref(py), true);
+        }
+        if let Some(cb) = on_connect {
+            spawn_callback_thread(connect_queue.clone(), node.clone(), cb, loop_obj.clone_ref(py), true);
+        }
+        if let Some(cb) = on_disconnect {
+            spawn_callback_thread(disconnect_queue.clone(), node.clone(), cb, loop_obj.clone_ref(py), false);
+        }
+
+        if event_loop.is_none() {
+            loop_obj.as_ref(py).call_method0("run_forever")?;
         }
     }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -7,6 +7,7 @@ use std::io::ErrorKind;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use serde::{Serialize, Deserialize};
+use serde_json;
 use bincode;
 
 use crate::memory::Shared;
@@ -249,6 +250,7 @@ pub async fn handle_peer(
     versions: Arc<Mutex<HashMap<String, u64>>>,
     peer_id: String,
     hash_check: bool,
+    disconnect_queue: Arc<Mutex<Vec<String>>>,
 ) -> Result<()> {
     let addr = sock.peer_addr().ok();
     println!("peer {:?} connected", addr);
@@ -288,6 +290,7 @@ pub async fn handle_peer(
             }
         }
     }
+    disconnect_queue.lock().unwrap().push(peer_id);
     println!("peer {:?} disconnected", addr);
     Ok(())
 }
@@ -297,6 +300,8 @@ pub async fn serve(
     rx: async_channel::Receiver<UpdatePacket>,
     state: Shared,
     pending_meta: Arc<Mutex<Option<String>>>,
+    connect_queue: Arc<Mutex<Vec<String>>>,
+    disconnect_queue: Arc<Mutex<Vec<String>>>,
 ) -> Result<()> {
     println!("listening on {}", addr);
     let lst = TcpListener::bind(addr).await?;
@@ -314,6 +319,7 @@ pub async fn serve(
                     let snap_hash = if sub.hash_check { Some(state.snapshot_hash()) } else { None };
                     let wire = WireUpdate { version: 0, updates: filtered, meta, hash: snap_hash };
                     if send_message(&mut sock, &wire).await.is_ok() {
+                        connect_queue.lock().unwrap().push(serde_json::to_string(&sub).unwrap());
                         conns.push((sock, sub));
                     }
                 }
@@ -335,7 +341,10 @@ pub async fn serve(
                     let wire = WireUpdate { version: u.version, updates: filtered, meta: u.meta.clone(), hash: hash_ref.cloned() };
                     match send_message(&mut s, &wire).await {
                         Ok(_) => alive.push((s, sub)),
-                        Err(e) => println!("send failed: {}", e),
+                        Err(e) => {
+                            println!("send failed: {}", e);
+                            disconnect_queue.lock().unwrap().push(sub.name.clone());
+                        }
                     }
                 }
                 conns = alive;
@@ -352,6 +361,8 @@ pub async fn client(
     meta: Arc<Mutex<Vec<String>>>,
     versions: Arc<Mutex<HashMap<String, u64>>>,
     sub: Subscription,
+    connect_queue: Arc<Mutex<Vec<String>>>,
+    disconnect_queue: Arc<Mutex<Vec<String>>>,
 ) -> Result<()> {
     let mut interval = time::interval(Duration::from_secs(1));
     loop {
@@ -362,6 +373,7 @@ pub async fn client(
                 if send_subscription(&mut sock, &sub).await.is_err() {
                     continue;
                 }
+                connect_queue.lock().unwrap().push(serde_json::to_string(&sub).unwrap());
                 let res = handle_peer(
                     sock,
                     state.clone(),
@@ -370,6 +382,7 @@ pub async fn client(
                     versions.clone(),
                     server.to_string(),
                     sub.hash_check,
+                    disconnect_queue.clone(),
                 ).await;
                 if let Err(e) = res {
                     println!("connection error {}: {}", server, e);
@@ -451,6 +464,7 @@ mod tests {
         let versions = Arc::new(Mutex::new(HashMap::new()));
         let meta = Arc::new(Mutex::new(Vec::new()));
         let named = Arc::new(HashMap::new());
+        let dq = Arc::new(Mutex::new(Vec::new()));
 
         let mut sock = TcpStream::connect(addr).await.unwrap();
         let sub = Subscription {
@@ -472,6 +486,7 @@ mod tests {
             versions.clone(),
             "srv".into(),
             false,
+            dq.clone(),
         )
         .await
         .unwrap();


### PR DESCRIPTION
## Summary
- refactor callback threads into helper `spawn_callback_thread`
- simplify loop/queue handling for async callbacks

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542dbe60a08332aa5ec27a1bc288f1