### PR TITLE
Fix removal of disconnected clients

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -290,7 +290,8 @@ pub async fn handle_peer(
             }
         }
     }
-    disconnect_queue.lock().unwrap().push(peer_id);
+    disconnect_queue.lock().unwrap().push(peer_id.clone());
+    versions.lock().unwrap().remove(&peer_id);
     println!("peer {:?} disconnected", addr);
     Ok(())
 }


### PR DESCRIPTION
## Summary
- drop disconnected peer version entries when a connection closes

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f2f662388332bd083951331294d4