### PR TITLE
Ensure write/read arrays are correctly shaped

### DIFF
--- a/examples/heatmap/heatmap_client.py
+++ b/examples/heatmap/heatmap_client.py
@@ -16,7 +16,6 @@ async def handle_update(node, meta):
     global size, chars
     print(meta)
     with node.read() as arr:
-        arr = arr.reshape(size, size)
         norm = (arr - arr.min()) / (np.ptp(arr) + 1e-9)
         levels = (norm * (len(chars) - 1)).astype(int)
         print("\033[H\033[J", end="")

--- a/examples/heatmap/heatmap_server.py
+++ b/examples/heatmap/heatmap_server.py
@@ -20,11 +20,9 @@ phase = 0.0
 while True:
     data = np.sin(X + phase) * np.cos(Y + phase)
     with node.write() as arr:
-        arr = arr.reshape(size, size)
         arr[:] = data
         node.version_meta({'phase': float(phase)})
     with node.read() as arr:
-        arr = arr.reshape(size, size)
         print("\033[H\033[J", end="")
         # display simple summary to avoid overwhelming the terminal
         print(f"phase: {phase:.2f} min {arr.min():.2f} max {arr.max():.2f}")

--- a/examples/life/life_client.py
+++ b/examples/life/life_client.py
@@ -23,7 +23,6 @@ else:
 
 while True:
     with node.read() as arr:
-        arr = arr.reshape(*view_shape)
         print("\033[H\033[J", end="")
         display = np.where(arr > 0, '#', '.')
         for row in display:

--- a/examples/life/life_server.py
+++ b/examples/life/life_server.py
@@ -23,11 +23,9 @@ while True:
     world = ((neighbours == 3) | ((world > 0) & (neighbours == 2))).astype(float)
 
     with node.write() as arr:
-        arr = arr.reshape(size, size)
         arr[:, :] = world
 
     with node.read() as arr:
-        arr = arr.reshape(size, size)
         print("\033[H\033[J", end="")
         display = np.where(arr > 0, '#', '.')
         for row in display:

--- a/examples/peer_split.py
+++ b/examples/peer_split.py
@@ -49,16 +49,14 @@ while True:
         # current loop counter. Using modulus keeps the numbers small
         # so changes between updates are visible.
         val = float((index + ordinal) % 4)
-        view = arr.reshape(dim, dim)
-        view[start[0]:start[0]+half, start[1]:start[1]+half] = val
+        arr[start[0]:start[0]+half, start[1]:start[1]+half] = val
         node.version_meta({'index': index})
     with node.read() as arr:
         print("\033[H\033[J", end="")
         version_str = ' '.join(f'{k}={v}' for k, v in node.version.items())
         print(f'peer {args.name} versions: {version_str}')
-        view = arr.reshape(dim, dim)
         for r in range(dim):
-            row_vals = view[r]
+            row_vals = arr[r]
             print(' '.join(f'{v:5.1f}' for v in row_vals))
         sys.stdout.flush()
     index += 1

--- a/examples/peer_stress.py
+++ b/examples/peer_stress.py
@@ -44,7 +44,6 @@ index = 0
 while True:
     with node.write() as arr:
         val = float((index + ordinal) % 4)
-        view = arr.reshape(dim, dim)
-        view[start[0]:start[0]+half, start[1]:start[1]+half] = val
+        arr[start[0]:start[0]+half, start[1]:start[1]+half] = val
         node.version_meta({'index': index})
     index += 1

--- a/examples/slices/slice_client.py
+++ b/examples/slices/slice_client.py
@@ -18,7 +18,6 @@ window = args.window
 
 async def handle_update(node, meta):
     with node.read() as arr:
-        arr = arr.reshape(len(tickers), window)
         print("\033[H\033[J", end="")
         for t, row in zip(tickers, arr):
             print(f'{t}: {row}')

--- a/examples/slices/slice_duckdb_client.py
+++ b/examples/slices/slice_duckdb_client.py
@@ -23,11 +23,11 @@ initialized = False
 async def handle_update(node, meta):
     global initialized
     if not initialized:
-        data = node.ndarray().reshape(len(tickers), window)
+        data = node.ndarray()
         con.register('data', data)
         initialized = True
     with node.read() as arr:
-        data = arr.reshape(len(tickers), window)
+        data = arr
         print(data.shape)
         result = con.execute(query).fetchall()[0]
         print("\033[H\033[J", end="")

--- a/examples/slices/slice_named_client.py
+++ b/examples/slices/slice_named_client.py
@@ -21,7 +21,7 @@ async def handle_update(node, meta):
         for t in tickers:
             arr = node.ndarray(f'ticker_{t}')
             if arr is not None:
-                data = np.array(arr).reshape(1, window)
+                data = np.array(arr)
                 print(f'{t}: {data[0]}')
         sys.stdout.flush()
 

--- a/examples/slices/slice_server.py
+++ b/examples/slices/slice_server.py
@@ -15,13 +15,11 @@ node = memblast.start('slice_server', listen=args.listen, shape=[args.tickers, a
 index = 0
 while True:
     with node.write() as arr:
-        arr = arr.reshape(args.tickers, args.window)
         for i in range(args.tickers):
             arr[i, index % args.window] = random.uniform(100.0, 200.0)
         node.version_meta({'index': index})
     index += 1
     with node.read() as data:
-        data = data.reshape(args.tickers, args.window)
         print("\033[H\033[J", end="")
         print(data)
         sys.stdout.flush()

--- a/examples/tickers/ticker_client.py
+++ b/examples/tickers/ticker_client.py
@@ -8,7 +8,7 @@ async def handle_update(node, meta):
     global latest_idx, tickers, window
     latest_idx = meta.get('index', latest_idx)
     with node.read() as arr:
-        data = np.array(arr).reshape(len(tickers), window)
+        data = np.array(arr)
         valid = min(latest_idx + 1, window)
         view = data[:, :valid] if valid > 0 else np.zeros((len(tickers), 0))
         means = view.mean(axis=1) if valid > 0 else np.zeros(len(tickers))

--- a/examples/tickers/ticker_duckdb_client.py
+++ b/examples/tickers/ticker_duckdb_client.py
@@ -10,11 +10,11 @@ async def handle_update(node, meta):
     global latest_idx, tickers, window, con, query_template, initialized
     latest_idx = meta.get('index', latest_idx)
     if not initialized:
-        data = node.ndarray().reshape(len(tickers), window)
+        data = node.ndarray()
         con.register('data', data)
         initialized = True
     with node.read() as arr:
-        data = np.array(arr).reshape(len(tickers), window)
+        data = np.array(arr)
         valid = min(latest_idx + 1, window)
         means = (
             con.execute(query_template.format(limit=valid)).fetchall()[0]

--- a/examples/tickers/ticker_server.py
+++ b/examples/tickers/ticker_server.py
@@ -18,13 +18,11 @@ node = memblast.start("ticker_server", listen=args.listen, shape=[len(tickers), 
 index = 0
 while True:
     with node.write() as arr:
-        arr = arr.reshape(len(tickers), window)
         if index < window:
             for i in range(len(tickers)):
                 arr[i, index] = random.uniform(100.0, 200.0)
         node.version_meta({'index': index})
     with node.read() as data:
-        data = data.reshape(len(tickers), window)
         print("\033[H\033[J", end="")
         for t, row in zip(tickers, data):
             print(t, row)

--- a/examples/yfinance/yfinance_duckdb_client.py
+++ b/examples/yfinance/yfinance_duckdb_client.py
@@ -19,12 +19,12 @@ initialized = False
 async def handle_update(node, meta):
     global initialized, con, query, tickers, window
     if not initialized:
-        data = node.ndarray().reshape(len(tickers), window)
+        data = node.ndarray()
         con.register('data', data)
         initialized = True
     print("\033[H\033[J", end="")
     with node.read() as arr:
-        data = arr.reshape(len(tickers), window)
+        data = arr
         means = con.execute(query).fetchall()[0]
     for i, (t, m) in enumerate(zip(tickers, means)):
         print(f'{t}: data: {data[i]} mean: {m:.2f}')

--- a/examples/yfinance/yfinance_server.py
+++ b/examples/yfinance/yfinance_server.py
@@ -42,13 +42,12 @@ while True:
             prices.append(float(data[t]['Close'].iloc[-1]))
 
     with node.write() as arr:
-        arr = arr.reshape(len(tickers), window)
         for i, price in enumerate(prices):
             arr[i, index % window] = price
         node.version_meta({'index': index})
 
     with node.read() as arr:
-        arr = np.array(arr).reshape(len(tickers), window)
+        arr = np.array(arr)
         print("\033[H\033[J", end="")
         for t, row in zip(tickers, arr):
             print(t, row)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,12 +49,12 @@ impl Node {
         }
         dict.into()
     }
-    fn ndarray<'py>(&'py self, py: Python<'py>, name: Option<&str>) -> Option<&'py PyArrayDyn<f64>> {
+    fn ndarray<'py>(slf: PyRef<'py, Self>, py: Python<'py>, name: Option<&str>) -> Option<&'py PyArrayDyn<f64>> {
         let (ptr, shape) = if let Some(n) = name {
-            let shared = self.named.get(n)?;
+            let shared = slf.named.get(n)?;
             (shared.mm.ptr(), shared.shape())
         } else {
-            (self.state.mm.ptr(), self.shape.as_slice())
+            (slf.state.mm.ptr(), slf.shape.as_slice())
         };
 
         let dims: Vec<npy_intp> = shape.iter().map(|&d| d as npy_intp).collect();
@@ -77,7 +77,7 @@ impl Node {
                 strides.as_ptr() as *mut npy_intp,
                 ptr,
                 NPY_ARRAY_WRITEABLE,
-                std::ptr::null_mut(),
+                slf.as_ptr(),
             );
             Some(PyArrayDyn::from_owned_ptr(py, arr_ptr))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,12 +60,10 @@ impl Node {
         let dims: Vec<npy_intp> = shape.iter().map(|&d| d as npy_intp).collect();
         let mut strides = vec![0isize as npy_intp; dims.len()];
         let elem = std::mem::size_of::<f64>() as npy_intp;
+        let mut stride = elem;
         for i in (0..dims.len()).rev() {
-            if i == dims.len() - 1 {
-                strides[i] = elem;
-            } else {
-                strides[i] = strides[i + 1] * dims[i + 1];
-            }
+            strides[i] = stride;
+            stride *= dims[i];
         }
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
@@ -192,12 +190,10 @@ impl WriteGuard {
         let dims: Vec<npy_intp> = cell.shape.iter().map(|&d| d as npy_intp).collect();
         let mut strides = vec![0isize as npy_intp; dims.len()];
         let elem = std::mem::size_of::<f64>() as npy_intp;
+        let mut stride = elem;
         for i in (0..dims.len()).rev() {
-            if i == dims.len() - 1 {
-                strides[i] = elem;
-            } else {
-                strides[i] = strides[i + 1] * dims[i + 1];
-            }
+            strides[i] = stride;
+            stride *= dims[i];
         }
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
@@ -245,12 +241,10 @@ impl ReadGuard {
         let arr = slf.arr.as_mut().unwrap();
         let mut strides = vec![0isize as npy_intp; dims.len()];
         let elem = std::mem::size_of::<f64>() as npy_intp;
+        let mut stride = elem;
         for i in (0..dims.len()).rev() {
-            if i == dims.len() - 1 {
-                strides[i] = elem;
-            } else {
-                strides[i] = strides[i + 1] * dims[i + 1];
-            }
+            strides[i] = stride;
+            stride *= dims[i];
         }
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use pyo3::prelude::*;
 use pyo3::types::{PyModule, PyDict};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
-use numpy::{Element, PyArray1};
+use numpy::{Element, PyArrayDyn};
 use numpy::npyffi::{PY_ARRAY_API, NpyTypes, NPY_ARRAY_WRITEABLE, npy_intp};
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
@@ -49,7 +49,7 @@ impl Node {
         }
         dict.into()
     }
-    fn ndarray<'py>(&'py self, py: Python<'py>, name: Option<&str>) -> Option<&'py PyArray1<f64>> {
+    fn ndarray<'py>(&'py self, py: Python<'py>, name: Option<&str>) -> Option<&'py PyArrayDyn<f64>> {
         let (ptr, shape) = if let Some(n) = name {
             let shared = self.named.get(n)?;
             (shared.mm.ptr(), shared.shape())
@@ -57,9 +57,16 @@ impl Node {
             (self.state.mm.ptr(), self.shape.as_slice())
         };
 
-        let len: usize = shape.iter().product();
-        let dims: [npy_intp; 1] = [len as npy_intp];
-        let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
+        let dims: Vec<npy_intp> = shape.iter().map(|&d| d as npy_intp).collect();
+        let mut strides = vec![0isize as npy_intp; dims.len()];
+        let elem = std::mem::size_of::<f64>() as npy_intp;
+        for i in (0..dims.len()).rev() {
+            if i == dims.len() - 1 {
+                strides[i] = elem;
+            } else {
+                strides[i] = strides[i + 1] * dims[i + 1];
+            }
+        }
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
             let descr = <f64 as Element>::get_dtype(py).into_dtype_ptr();
@@ -74,7 +81,7 @@ impl Node {
                 NPY_ARRAY_WRITEABLE,
                 std::ptr::null_mut(),
             );
-            Some(PyArray1::from_owned_ptr(py, arr_ptr))
+            Some(PyArrayDyn::from_owned_ptr(py, arr_ptr))
         }
     }
 
@@ -180,10 +187,18 @@ struct WriteGuard {
 
 #[pymethods]
 impl WriteGuard {
-    fn __enter__<'py>(slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArray1<f64> {
+    fn __enter__<'py>(slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArrayDyn<f64> {
         let cell = slf.node.as_ref(py).borrow();
-        let dims: [npy_intp; 1] = [cell.len as npy_intp];
-        let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
+        let dims: Vec<npy_intp> = cell.shape.iter().map(|&d| d as npy_intp).collect();
+        let mut strides = vec![0isize as npy_intp; dims.len()];
+        let elem = std::mem::size_of::<f64>() as npy_intp;
+        for i in (0..dims.len()).rev() {
+            if i == dims.len() - 1 {
+                strides[i] = elem;
+            } else {
+                strides[i] = strides[i + 1] * dims[i + 1];
+            }
+        }
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
             let descr = <f64 as Element>::get_dtype(py).into_dtype_ptr();
@@ -198,7 +213,7 @@ impl WriteGuard {
                 NPY_ARRAY_WRITEABLE,
                 cell.as_ptr(),
             );
-            PyArray1::from_owned_ptr(py, arr_ptr)
+            PyArrayDyn::from_owned_ptr(py, arr_ptr)
         }
     }
 
@@ -222,10 +237,21 @@ struct ReadGuard {
 
 #[pymethods]
 impl ReadGuard {
-    fn __enter__<'py>(mut slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArray1<f64> {
+    fn __enter__<'py>(mut slf: PyRefMut<'py, Self>, py: Python<'py>) -> &'py PyArrayDyn<f64> {
+        let dims: Vec<npy_intp> = {
+            let cell = slf.node.as_ref(py).borrow();
+            cell.shape.iter().map(|&d| d as npy_intp).collect()
+        };
         let arr = slf.arr.as_mut().unwrap();
-        let dims: [npy_intp; 1] = [arr.len() as npy_intp];
-        let strides: [npy_intp; 1] = [std::mem::size_of::<f64>() as npy_intp];
+        let mut strides = vec![0isize as npy_intp; dims.len()];
+        let elem = std::mem::size_of::<f64>() as npy_intp;
+        for i in (0..dims.len()).rev() {
+            if i == dims.len() - 1 {
+                strides[i] = elem;
+            } else {
+                strides[i] = strides[i + 1] * dims[i + 1];
+            }
+        }
         unsafe {
             let subtype = PY_ARRAY_API.get_type_object(py, NpyTypes::PyArray_Type);
             let descr = <f64 as Element>::get_dtype(py).into_dtype_ptr();
@@ -240,7 +266,7 @@ impl ReadGuard {
                 0,
                 std::ptr::null_mut(),
             );
-            PyArray1::from_owned_ptr(py, arr_ptr)
+            PyArrayDyn::from_owned_ptr(py, arr_ptr)
         }
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import socket
+import contextlib
+import pytest
+
+@pytest.fixture
+def free_tcp_port():
+    with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(('127.0.0.1', 0))
+        addr, port = s.getsockname()
+    return port

--- a/tests/test_fill_rows.py
+++ b/tests/test_fill_rows.py
@@ -1,0 +1,11 @@
+import memblast
+
+def test_fill_rows():
+    node = memblast.start("rows", shape=[10, 10])
+    with node.write() as arr:
+        for i in range(10):
+            arr[i] = float(i)
+    with node.read() as arr:
+        for i in range(10):
+            for j in range(10):
+                assert arr[i, j] == float(i)

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -1,0 +1,11 @@
+import memblast
+
+
+def test_write_guard_shape():
+    node = memblast.start("sh", shape=[2, 3])
+    with node.write() as arr:
+        assert arr.shape == (2, 3)
+        arr[0, 0] = 1.0
+    with node.read() as arr:
+        assert arr.shape == (2, 3)
+        assert arr[0, 0] == 1.0


### PR DESCRIPTION
## Summary
- expose arrays with full shape from Rust
- update Python examples to use shaped arrays directly
- add regression test for array shape

## Testing
- `maturin develop --release`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68588344a8e48332acd97fda5e0c5872